### PR TITLE
Make duplicate scanning sync-safe; purge derived caches on remote delete

### DIFF
--- a/App/Classes/DuplicateScanManager.swift
+++ b/App/Classes/DuplicateScanManager.swift
@@ -70,8 +70,13 @@ class DuplicateScanManager {
 
         scanTotal = uncachedIDs.count
 
+        // Hash from the thumbnail, not the full-resolution original. Thumbnails are stored in the
+        // synced database row and are never evicted, whereas originals are routinely absent locally
+        // once iCloud sync is on (Optimize storage evicts them after upload, and pics arriving from
+        // other devices only download their originals on demand). DHash downscales to 9x8 anyway, so
+        // the thumbnail yields an effectively identical hash while keeping the scan complete offline.
         for picID in uncachedIDs {
-            if let data = await dataActor.imageData(forPicWithID: picID),
+            if let data = await dataActor.thumbnailData(forPicWithID: picID),
                let image = UIImage(data: data),
                let hash = DHash.compute(from: image) {
                 await HashActor.shared.storeHash(hash, forPicWithID: picID)

--- a/App/Classes/DuplicateScanManager.swift
+++ b/App/Classes/DuplicateScanManager.swift
@@ -70,11 +70,7 @@ class DuplicateScanManager {
 
         scanTotal = uncachedIDs.count
 
-        // Hash from the thumbnail, not the full-resolution original. Thumbnails are stored in the
-        // synced database row and are never evicted, whereas originals are routinely absent locally
-        // once iCloud sync is on (Optimize storage evicts them after upload, and pics arriving from
-        // other devices only download their originals on demand). DHash downscales to 9x8 anyway, so
-        // the thumbnail yields an effectively identical hash while keeping the scan complete offline.
+        // Hash the synced thumbnail, not the original (which sync may evict or never download).
         for picID in uncachedIDs {
             if let data = await dataActor.thumbnailData(forPicWithID: picID),
                let image = UIImage(data: data),

--- a/App/Classes/SyncMate+Delegate.swift
+++ b/App/Classes/SyncMate+Delegate.swift
@@ -110,6 +110,7 @@ extension SyncMate: CKSyncEngineDelegate {
             }
             await applyRecord(modification.record)
         }
+        var deletedPicIDsByCollection: [String: [String]] = [:]
         for deletion in changes.deletions {
             if deletion.recordID.zoneID.zoneName == Self.librariesZoneName {
                 libraryChanged = true
@@ -124,7 +125,16 @@ extension SyncMate: CKSyncEngineDelegate {
                 await OriginalsManager.shared.deleteCloudOriginal(
                     picID: deletion.recordID.recordName, in: dataActor.collectionID
                 )
+                deletedPicIDsByCollection[dataActor.collectionID, default: []]
+                    .append(deletion.recordID.recordName)
             }
+        }
+        // Purge the local-only derived caches (perceptual hashes for duplicate scanning, prominent
+        // colors for color sort) for remotely-deleted pics. These caches aren't synced, so without
+        // this their rows would orphan and accumulate forever as deletions arrive from other devices.
+        for (collectionID, picIDs) in deletedPicIDsByCollection {
+            await HashActor.instance(for: collectionID).deleteHashes(forPicIDs: picIDs)
+            await PColorActor.instance(for: collectionID).deleteColors(forPicIDs: picIDs)
         }
         if !changes.modifications.isEmpty || !changes.deletions.isEmpty {
             await MainActor.run {

--- a/App/Classes/SyncMate+Delegate.swift
+++ b/App/Classes/SyncMate+Delegate.swift
@@ -129,9 +129,7 @@ extension SyncMate: CKSyncEngineDelegate {
                     .append(deletion.recordID.recordName)
             }
         }
-        // Purge the local-only derived caches (perceptual hashes for duplicate scanning, prominent
-        // colors for color sort) for remotely-deleted pics. These caches aren't synced, so without
-        // this their rows would orphan and accumulate forever as deletions arrive from other devices.
+        // Purge local-only derived caches (hashes, colors) for remotely-deleted pics.
         for (collectionID, picIDs) in deletedPicIDsByCollection {
             await HashActor.instance(for: collectionID).deleteHashes(forPicIDs: picIDs)
             await PColorActor.instance(for: collectionID).deleteColors(forPicIDs: picIDs)

--- a/Shared/Data Actor/HashActor.swift
+++ b/Shared/Data Actor/HashActor.swift
@@ -6,19 +6,14 @@ actor HashActor {
     nonisolated(unsafe) private static var _shared = HashActor(collectionID: PicLibrary.defaultID)
     static var shared: HashActor { _shared }
 
-    /// Bumped to 2 when duplicate scanning switched from hashing full-resolution originals to
-    /// hashing the (always-present, synced) thumbnail. Hashes stored under an older version are
-    /// treated as uncached so they get recomputed from the thumbnail on the next scan.
+    /// Bumped to 2 when scanning switched from hashing originals to hashing thumbnails; older
+    /// hashes are treated as uncached and recomputed.
     static let currentHashVersion = 2
 
     static func switchLibrary(to collectionID: String) {
         _shared = HashActor(collectionID: collectionID)
     }
 
-    /// Returns the shared instance when it already targets the requested library, otherwise a
-    /// transient instance bound to that library's hash database. Mirrors `DataActor.instance(for:)`
-    /// so callers (e.g. sync) can address a non-active library's cache without disturbing the
-    /// active one's connection.
     static func instance(for collectionID: String) -> HashActor {
         if collectionID == _shared.collectionID {
             return _shared

--- a/Shared/Data Actor/HashActor.swift
+++ b/Shared/Data Actor/HashActor.swift
@@ -6,9 +6,27 @@ actor HashActor {
     nonisolated(unsafe) private static var _shared = HashActor(collectionID: PicLibrary.defaultID)
     static var shared: HashActor { _shared }
 
+    /// Bumped to 2 when duplicate scanning switched from hashing full-resolution originals to
+    /// hashing the (always-present, synced) thumbnail. Hashes stored under an older version are
+    /// treated as uncached so they get recomputed from the thumbnail on the next scan.
+    static let currentHashVersion = 2
+
     static func switchLibrary(to collectionID: String) {
         _shared = HashActor(collectionID: collectionID)
     }
+
+    /// Returns the shared instance when it already targets the requested library, otherwise a
+    /// transient instance bound to that library's hash database. Mirrors `DataActor.instance(for:)`
+    /// so callers (e.g. sync) can address a non-active library's cache without disturbing the
+    /// active one's connection.
+    static func instance(for collectionID: String) -> HashActor {
+        if collectionID == _shared.collectionID {
+            return _shared
+        }
+        return HashActor(collectionID: collectionID)
+    }
+
+    nonisolated let collectionID: String
 
     let database: Connection
 
@@ -19,6 +37,7 @@ actor HashActor {
     let hashVersion = Expression<Int>("hash_version")
 
     init(collectionID: String) {
+        self.collectionID = collectionID
         let databaseFileName = "Hashes.db"
         let fileManager = FileManager.default
 
@@ -68,7 +87,9 @@ actor HashActor {
     }
 
     func allCachedHashes() -> [(String, UInt64)] {
-        let query = picHashesTable.select(hashPicId, hashValue)
+        let query = picHashesTable
+            .filter(hashVersion == Self.currentHashVersion)
+            .select(hashPicId, hashValue)
         guard let rows = try? database.prepare(query) else { return [] }
         return rows.compactMap { row in
             guard let picID = try? row.get(hashPicId),
@@ -78,7 +99,9 @@ actor HashActor {
     }
 
     func picIDsWithCachedHash() -> Set<String> {
-        let query = picHashesTable.select(hashPicId)
+        let query = picHashesTable
+            .filter(hashVersion == Self.currentHashVersion)
+            .select(hashPicId)
         guard let rows = try? database.prepare(query) else { return [] }
         var ids = Set<String>()
         for row in rows {
@@ -96,7 +119,7 @@ actor HashActor {
         _ = try? database.run(picHashesTable.insert(or: .replace,
             hashPicId <- picID,
             hashValue <- signedHash,
-            hashVersion <- 1
+            hashVersion <- Self.currentHashVersion
         ))
     }
 
@@ -104,6 +127,12 @@ actor HashActor {
 
     func deleteHash(forPicWithID picID: String) {
         let query = picHashesTable.filter(hashPicId == picID)
+        _ = try? database.run(query.delete())
+    }
+
+    func deleteHashes(forPicIDs picIDs: [String]) {
+        guard !picIDs.isEmpty else { return }
+        let query = picHashesTable.filter(picIDs.contains(hashPicId))
         _ = try? database.run(query.delete())
     }
 

--- a/Shared/Data Actor/PColorActor.swift
+++ b/Shared/Data Actor/PColorActor.swift
@@ -10,10 +10,6 @@ actor PColorActor {
         _shared = PColorActor(collectionID: collectionID)
     }
 
-    /// Returns the shared instance when it already targets the requested library, otherwise a
-    /// transient instance bound to that library's color database. Mirrors `DataActor.instance(for:)`
-    /// so callers (e.g. sync) can address a non-active library's cache without disturbing the
-    /// active one's connection.
     static func instance(for collectionID: String) -> PColorActor {
         if collectionID == _shared.collectionID {
             return _shared

--- a/Shared/Data Actor/PColorActor.swift
+++ b/Shared/Data Actor/PColorActor.swift
@@ -10,6 +10,19 @@ actor PColorActor {
         _shared = PColorActor(collectionID: collectionID)
     }
 
+    /// Returns the shared instance when it already targets the requested library, otherwise a
+    /// transient instance bound to that library's color database. Mirrors `DataActor.instance(for:)`
+    /// so callers (e.g. sync) can address a non-active library's cache without disturbing the
+    /// active one's connection.
+    static func instance(for collectionID: String) -> PColorActor {
+        if collectionID == _shared.collectionID {
+            return _shared
+        }
+        return PColorActor(collectionID: collectionID)
+    }
+
+    nonisolated let collectionID: String
+
     let database: Connection
 
     let picColorsTable = Table("pic_colors")
@@ -20,6 +33,7 @@ actor PColorActor {
     let colorBlue = Expression<Int>("blue")
 
     init(collectionID: String) {
+        self.collectionID = collectionID
         let databaseFileName = "PColors.db"
         let fileManager = FileManager.default
 


### PR DESCRIPTION
## Why

This verifies and remediates how the newly added iCloud sync (#100) interacts with **duplicate scanning** and **color sort**.

### Findings

**Color sort — already robust.** It derives the prominent color from `thumbnailData`, which lives in the synced DB row and is never evicted. Remote-added pics sort correctly and Optimize storage doesn't affect it. No behavioral change needed.

**Duplicate scanning — broken under sync.** The scan hashed the **full-resolution original** via `imageData(forPicWithID:)`, but with sync on the original is routinely *not* on device:
- The default **Optimize** storage mode evicts local originals after upload (`reclaimUploadedOriginals` → `evictLocalOriginal` nulls `picFilePath` and deletes the file).
- Pics arriving from other devices keep their originals in iCloud Drive and download them only on demand.

When `imageData` returned `nil`, the scan loop silently skipped the pic (`scanProgress += 1`) — no hash, no error, no "N skipped" feedback. Result: scans silently under-report duplicates once sync is enabled.

**Cache hygiene.** The perceptual-hash cache (`Hashes.db`) and color cache (`PColors.db`) are local-only, keyed by pic ID. Local deletes clean the color cache, but the sync delete path (`removePicForRemoteDelete`) cleaned neither — so deletions arriving from other devices orphaned cache rows that accumulated indefinitely. (Orphans were harmless to results — filtered out by scope — but leaked storage.)

## Changes

- **Hash from the thumbnail, not the original** (`DuplicateScanManager`). `DHash` downscales to 9×8 regardless, so the thumbnail yields an effectively identical hash while keeping scans complete offline and far faster. Bumped `HashActor.currentHashVersion` to `2` and filtered reads by version so legacy original-derived hashes are treated as uncached and recomputed once from thumbnails.
- **Purge derived caches on remote delete** (`SyncMate+Delegate`). Collected remotely-deleted pic IDs per library and batch-deleted their hash/color rows. Added per-collection `HashActor.instance(for:)` / `PColorActor.instance(for:)` accessors (mirroring `DataActor.instance(for:)`) and a batch `HashActor.deleteHashes(forPicIDs:)` so non-active libraries are addressed without disturbing the active connection.

## Notes / verification

- No Swift toolchain in the CI environment, so changes were verified by review. The `hash_version` column already exists on older installs (default `1` via `DatabaseMigrator`), so the version bump cleanly invalidates legacy hashes.
- `PhotosDuplicateScanManager` shares the hash table but uses a separate ID namespace; it recomputes its hashes once after the version bump and is otherwise unaffected.

https://claude.ai/code/session_01PXNTdQQbNmP4QUqcDdNjtp

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXNTdQQbNmP4QUqcDdNjtp)_