### PR TITLE
Reclaim disk space correctly after image migration

### DIFF
--- a/App/Views/Libraries/EditLibrarySheet.swift
+++ b/App/Views/Libraries/EditLibrarySheet.swift
@@ -372,7 +372,10 @@ struct EditLibrarySheet: View {
             UIApplication.shared.isIdleTimerDisabled = true
             isFreeingUpSpace = true
         }
-        await dataActor.vacuum()
+        let reclaimed = await dataActor.reclaimDiskSpace()
+        if !reclaimed {
+            debugPrint("Free up space: no disk space was reclaimed")
+        }
         await MainActor.run {
             isFreeingUpSpace = false
             UIApplication.shared.isIdleTimerDisabled = false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,6 @@
 # Code style
 
-- Keep comments concise. Prefer a single short line that explains *why*, not
-  *what*. Avoid multi-line explanatory comment blocks and doc comments that
-  restate the code.
+- If the code is self-explanatory, write no comment at all.
+- Only comment to explain *why* something non-obvious is done (e.g. a
+  surprising API requirement or workaround), never to restate *what* the code
+  does. No multi-line explanatory blocks or doc comments that echo the code.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# Code style
+
+- Keep comments concise. Prefer a single short line that explains *why*, not
+  *what*. Avoid multi-line explanatory comment blocks and doc comments that
+  restate the code.

--- a/Shared/Data Actor/DataActor+ImageMigration.swift
+++ b/Shared/Data Actor/DataActor+ImageMigration.swift
@@ -60,7 +60,11 @@ extension DataActor {
 
         let batchSize = chosenBatchSize(total: total)
         let singleBatch = batchSize >= total
-        if !singleBatch { ensureIncrementalVacuumActive() }
+        // Put the database into incremental auto_vacuum mode up front so that
+        // freed pages can be released cheaply after each batch without needing
+        // scratch space for a full rebuild. New databases are already
+        // incremental; existing ones are converted here when there is room.
+        ensureIncrementalAutoVacuum()
         var copied = 0
         var verified = 0
         var start = 0
@@ -86,7 +90,11 @@ extension DataActor {
                                                       latestThumbnail: thumbnailData(forPicWithID: id)))
             }
             for id in verifiedIDs {
-                _ = try? database.run(picsTable.filter(picId == id).update(picData <- nil))
+                do {
+                    try database.run(picsTable.filter(picId == id).update(picData <- nil))
+                } catch {
+                    debugPrint("Failed to clear migrated blob for \(id): \(error)")
+                }
             }
             if !singleBatch {
                 await progress(ImageMigrationProgress(phase: .reclaiming, completed: 0,
@@ -98,7 +106,9 @@ extension DataActor {
         await progress(ImageMigrationProgress(phase: .reclaiming, completed: 0,
                                               total: 0, latestThumbnail: nil))
         try? await Task.sleep(for: .seconds(1))
-        vacuum()
+        if !reclaimDiskSpace() {
+            debugPrint("Image migration: final disk space reclamation freed no space")
+        }
     }
 
     // MARK: - Helpers
@@ -137,8 +147,8 @@ extension DataActor {
     }
 
     private func chosenBatchSize(total: Int) -> Int {
-        let free = availableFreeBytes()
-        let payload = currentDatabaseFileSize()
+        let free = freeBytesAtDatabaseLocation()
+        let payload = databaseFileSizeBytes()
         guard payload > 0, free > 0 else { return total }
         if free > 2 * payload { return total }
         let averageEntry = payload / Int64(max(total, 1))
@@ -147,29 +157,16 @@ extension DataActor {
         return max(1, Int((Double(total) / Double(batchCount)).rounded(.up)))
     }
 
-    private func availableFreeBytes() -> Int64 {
-        let values = try? databaseURL.resourceValues(
-            forKeys: [.volumeAvailableCapacityForImportantUsageKey]
-        )
-        return values?.volumeAvailableCapacityForImportantUsage ?? Int64.max
-    }
-
-    private func currentDatabaseFileSize() -> Int64 {
-        let attributes = try? FileManager.default.attributesOfItem(atPath: databaseURL.path)
-        return (attributes?[.size] as? NSNumber)?.int64Value ?? 0
-    }
-
     private func reclaimSpaceIncrementally() {
-        _ = try? database.execute("PRAGMA incremental_vacuum;")
-    }
-
-    private func ensureIncrementalVacuumActive() {
-        // 2 == SQLITE_AUTO_VACUUM_INCREMENTAL.
-        guard let mode = (try? database.scalar("PRAGMA auto_vacuum")) as? Int64,
-              mode != 2 else { return }
-        guard currentDatabaseFileSize() < availableFreeBytes() else { return }
-        _ = try? database.execute("PRAGMA auto_vacuum = INCREMENTAL;")
-        _ = try? database.vacuum()
+        // `PRAGMA incremental_vacuum` only releases pages when the database is
+        // actually in incremental auto_vacuum mode; in any other mode it is a
+        // silent no-op, so skip it rather than pretending space was reclaimed.
+        guard autoVacuumMode() == 2 else { return }
+        do {
+            try database.execute("PRAGMA incremental_vacuum;")
+        } catch {
+            debugPrint("Incremental vacuum failed: \(error)")
+        }
     }
 }
 

--- a/Shared/Data Actor/DataActor+ImageMigration.swift
+++ b/Shared/Data Actor/DataActor+ImageMigration.swift
@@ -60,10 +60,7 @@ extension DataActor {
 
         let batchSize = chosenBatchSize(total: total)
         let singleBatch = batchSize >= total
-        // Put the database into incremental auto_vacuum mode up front so that
-        // freed pages can be released cheaply after each batch without needing
-        // scratch space for a full rebuild. New databases are already
-        // incremental; existing ones are converted here when there is room.
+        // Enable incremental auto_vacuum so per-batch reclaim is cheap.
         ensureIncrementalAutoVacuum()
         var copied = 0
         var verified = 0
@@ -158,9 +155,7 @@ extension DataActor {
     }
 
     private func reclaimSpaceIncrementally() {
-        // `PRAGMA incremental_vacuum` only releases pages when the database is
-        // actually in incremental auto_vacuum mode; in any other mode it is a
-        // silent no-op, so skip it rather than pretending space was reclaimed.
+        // Only effective in incremental mode; a no-op otherwise.
         guard autoVacuumMode() == 2 else { return }
         do {
             try database.execute("PRAGMA incremental_vacuum;")

--- a/Shared/Data Actor/DataActor+ImageMigration.swift
+++ b/Shared/Data Actor/DataActor+ImageMigration.swift
@@ -60,7 +60,6 @@ extension DataActor {
 
         let batchSize = chosenBatchSize(total: total)
         let singleBatch = batchSize >= total
-        // Enable incremental auto_vacuum so per-batch reclaim is cheap.
         ensureIncrementalAutoVacuum()
         var copied = 0
         var verified = 0
@@ -155,7 +154,7 @@ extension DataActor {
     }
 
     private func reclaimSpaceIncrementally() {
-        // Only effective in incremental mode; a no-op otherwise.
+        // incremental_vacuum is a no-op outside incremental mode.
         guard autoVacuumMode() == 2 else { return }
         do {
             try database.execute("PRAGMA incremental_vacuum;")

--- a/Shared/Data Actor/DataActor.swift
+++ b/Shared/Data Actor/DataActor.swift
@@ -168,18 +168,12 @@ actor DataActor {
         ((try? database.scalar("PRAGMA auto_vacuum")) as? Int64) ?? 0
     }
 
-    /// Ensures the database is in incremental auto_vacuum mode so that free
-    /// pages can later be released with a cheap `PRAGMA incremental_vacuum`
-    /// that needs no scratch space. Switching the mode on an already-populated
-    /// database is a no-op until a full `VACUUM` runs, so this performs that
-    /// one-time conversion — but only when there is enough free space for the
-    /// rebuild. Returns whether the database ends up in incremental mode.
+    /// Switches an existing database to incremental auto_vacuum. The mode change
+    /// only applies after a full VACUUM, so this runs one when space allows.
     @discardableResult
     func ensureIncrementalAutoVacuum() -> Bool {
         if autoVacuumMode() == 2 { return true }
         _ = try? database.execute("PRAGMA auto_vacuum = INCREMENTAL;")
-        // The mode change only takes effect after a full VACUUM, which needs
-        // scratch space roughly equal to the current file size.
         guard freeBytesAtDatabaseLocation() > databaseFileSizeBytes() else { return false }
         do {
             try database.vacuum()
@@ -189,15 +183,10 @@ actor DataActor {
         return autoVacuumMode() == 2
     }
 
-    /// Reclaims free pages back to the filesystem and reports whether space was
-    /// actually reclaimed. Prefers incremental vacuum (no scratch space
-    /// required) when the database is in incremental auto_vacuum mode, falling
-    /// back to a full `VACUUM` otherwise. Unlike a bare `VACUUM`, failures are
-    /// surfaced rather than silently swallowed.
+    /// Releases free pages to the filesystem, preferring incremental vacuum and
+    /// falling back to a full VACUUM. Returns whether reclamation succeeded.
     @discardableResult
     func reclaimDiskSpace() -> Bool {
-        // Try to put the database into incremental mode so this and future
-        // reclamations are cheap and don't depend on having 2x free space.
         if ensureIncrementalAutoVacuum() {
             do {
                 try database.execute("PRAGMA incremental_vacuum;")
@@ -207,8 +196,6 @@ actor DataActor {
                 return false
             }
         }
-        // Not in incremental mode (e.g. too little free space to convert):
-        // attempt a full VACUUM, which reclaims everything when it succeeds.
         do {
             try database.vacuum()
             return true

--- a/Shared/Data Actor/DataActor.swift
+++ b/Shared/Data Actor/DataActor.swift
@@ -163,8 +163,76 @@ actor DataActor {
         }
     }
 
-    func vacuum() {
-        _ = try? self.database.vacuum()
+    /// Current auto_vacuum mode: 0 = NONE, 1 = FULL, 2 = INCREMENTAL.
+    func autoVacuumMode() -> Int64 {
+        ((try? database.scalar("PRAGMA auto_vacuum")) as? Int64) ?? 0
+    }
+
+    /// Ensures the database is in incremental auto_vacuum mode so that free
+    /// pages can later be released with a cheap `PRAGMA incremental_vacuum`
+    /// that needs no scratch space. Switching the mode on an already-populated
+    /// database is a no-op until a full `VACUUM` runs, so this performs that
+    /// one-time conversion — but only when there is enough free space for the
+    /// rebuild. Returns whether the database ends up in incremental mode.
+    @discardableResult
+    func ensureIncrementalAutoVacuum() -> Bool {
+        if autoVacuumMode() == 2 { return true }
+        _ = try? database.execute("PRAGMA auto_vacuum = INCREMENTAL;")
+        // The mode change only takes effect after a full VACUUM, which needs
+        // scratch space roughly equal to the current file size.
+        guard freeBytesAtDatabaseLocation() > databaseFileSizeBytes() else { return false }
+        do {
+            try database.vacuum()
+        } catch {
+            debugPrint("Auto-vacuum conversion VACUUM failed: \(error)")
+        }
+        return autoVacuumMode() == 2
+    }
+
+    /// Reclaims free pages back to the filesystem and reports whether space was
+    /// actually reclaimed. Prefers incremental vacuum (no scratch space
+    /// required) when the database is in incremental auto_vacuum mode, falling
+    /// back to a full `VACUUM` otherwise. Unlike a bare `VACUUM`, failures are
+    /// surfaced rather than silently swallowed.
+    @discardableResult
+    func reclaimDiskSpace() -> Bool {
+        // Try to put the database into incremental mode so this and future
+        // reclamations are cheap and don't depend on having 2x free space.
+        if ensureIncrementalAutoVacuum() {
+            do {
+                try database.execute("PRAGMA incremental_vacuum;")
+                return true
+            } catch {
+                debugPrint("Incremental vacuum failed: \(error)")
+                return false
+            }
+        }
+        // Not in incremental mode (e.g. too little free space to convert):
+        // attempt a full VACUUM, which reclaims everything when it succeeds.
+        do {
+            try database.vacuum()
+            return true
+        } catch {
+            debugPrint("VACUUM failed: \(error)")
+            return false
+        }
+    }
+
+    @discardableResult
+    func vacuum() -> Bool {
+        reclaimDiskSpace()
+    }
+
+    func databaseFileSizeBytes() -> Int64 {
+        let attributes = try? FileManager.default.attributesOfItem(atPath: databaseURL.path)
+        return (attributes?[.size] as? NSNumber)?.int64Value ?? 0
+    }
+
+    func freeBytesAtDatabaseLocation() -> Int64 {
+        let values = try? databaseURL.resourceValues(
+            forKeys: [.volumeAvailableCapacityForImportantUsageKey]
+        )
+        return values?.volumeAvailableCapacityForImportantUsage ?? Int64.max
     }
 
     // MARK: - Row to Model Helpers

--- a/Shared/Data Actor/DataActor.swift
+++ b/Shared/Data Actor/DataActor.swift
@@ -168,12 +168,11 @@ actor DataActor {
         ((try? database.scalar("PRAGMA auto_vacuum")) as? Int64) ?? 0
     }
 
-    /// Switches an existing database to incremental auto_vacuum. The mode change
-    /// only applies after a full VACUUM, so this runs one when space allows.
     @discardableResult
     func ensureIncrementalAutoVacuum() -> Bool {
         if autoVacuumMode() == 2 { return true }
         _ = try? database.execute("PRAGMA auto_vacuum = INCREMENTAL;")
+        // The mode change only takes effect after a full VACUUM.
         guard freeBytesAtDatabaseLocation() > databaseFileSizeBytes() else { return false }
         do {
             try database.vacuum()
@@ -183,8 +182,6 @@ actor DataActor {
         return autoVacuumMode() == 2
     }
 
-    /// Releases free pages to the filesystem, preferring incremental vacuum and
-    /// falling back to a full VACUUM. Returns whether reclamation succeeded.
     @discardableResult
     func reclaimDiskSpace() -> Bool {
         if ensureIncrementalAutoVacuum() {


### PR DESCRIPTION
## Problem

After the blob-to-file image migration, the original data appeared to remain in `Collection.db` — the file never shrank even though the rows were cleared.

The migration *did* logically remove the data (`picData` set to `NULL`), but the freed pages were never released back to the filesystem:

1. **`PRAGMA auto_vacuum = INCREMENTAL` in `DataActor.init` is a no-op on an already-populated database.** SQLite only applies an `auto_vacuum` mode change after a full `VACUUM`, so existing libraries stayed in `NONE` mode.
2. **Because the mode was never actually incremental, the per-batch `PRAGMA incremental_vacuum` calls were silent no-ops** — they only release pages in incremental mode.
3. **The final `VACUUM` swallowed its error** (`_ = try? database.vacuum()`), so failures — including the low-disk-space scenario the batching is specifically designed for — went completely unnoticed.

Net effect: on the single-batch / plenty-of-space path it worked (the final full `VACUUM` succeeded), but on the multi-batch / low-space path the file never shrank.

## Changes

- **`DataActor`**: added `autoVacuumMode()`, `ensureIncrementalAutoVacuum()` (performs the one-time conversion `VACUUM` when there's room), and `reclaimDiskSpace()` which prefers a cheap `incremental_vacuum` and falls back to a full `VACUUM`, **surfacing failures** instead of discarding them. Consolidated the duplicated free-space / file-size helpers here.
- **Image migration**: establishes incremental mode up front, makes per-batch reclaim mode-aware, uses `reclaimDiskSpace()` for the final reclaim, and logs blob-clearing failures instead of ignoring them.
- **"Free up space"** in the library sheet now calls `reclaimDiskSpace()` so it actually releases free pages back to the filesystem.

## Notes

- New databases continue to get incremental mode from birth (the `init` pragma runs before tables exist).
- For existing low-space libraries, the final reclaim still works: after the blobs are nulled, the compacted output is small, so a full `VACUUM` needs little scratch space — and any failure is now logged rather than hidden.
- No Swift toolchain is available in this environment (iOS app), so changes were verified by review rather than compilation.

https://claude.ai/code/session_01F7iErXJKjWyKEWXGHkpv6R

---
_Generated by [Claude Code](https://claude.ai/code/session_01F7iErXJKjWyKEWXGHkpv6R)_