### PR TITLE
Improve post-migration disk cleanup and gate sync on migration completion

### DIFF
--- a/App/Views/App.swift
+++ b/App/Views/App.swift
@@ -57,6 +57,7 @@ struct IllustMateApp: App {
         .environment(auth)
         .environment(pipManager)
         .environment(webServer)
+        .environment(imageMigration)
         .overlay(alignment: .bottomLeading) {
             PictureInPictureLayerView(pipManager: pipManager)
                 .frame(width: 1, height: 1)

--- a/App/Views/Libraries/EditLibrarySheet.swift
+++ b/App/Views/Libraries/EditLibrarySheet.swift
@@ -372,6 +372,7 @@ struct EditLibrarySheet: View {
             UIApplication.shared.isIdleTimerDisabled = true
             isFreeingUpSpace = true
         }
+        await dataActor.purgeMigratedBlobs()
         let reclaimed = await dataActor.reclaimDiskSpace()
         if !reclaimed {
             debugPrint("Free up space: no disk space was reclaimed")

--- a/App/Views/Libraries/EditLibrarySheet.swift
+++ b/App/Views/Libraries/EditLibrarySheet.swift
@@ -5,6 +5,7 @@ struct EditLibrarySheet: View {
 
     @Environment(\.dismiss) var dismiss
     @Environment(ConcurrencyManager.self) var concurrency
+    @Environment(ImageMigrationManager.self) var imageMigration
     @EnvironmentObject var libraryManager: LibraryManager
     @EnvironmentObject var navigation: NavigationManager
 
@@ -26,6 +27,7 @@ struct EditLibrarySheet: View {
     @State var isConfirmingFreeUpSpace: Bool = false
     @State var isFreeingUpSpace: Bool = false
     @State var isConfirmingClearCache: Bool = false
+    @State var migrationIncomplete: Bool = false
 
     @State var libraryToDelete: PicLibrary?
     @State var deleteConfirmationCode: String = ""
@@ -79,6 +81,7 @@ struct EditLibrarySheet: View {
                     )) {
                         Text("Sync.Title", tableName: "More")
                     }
+                    .disabled(migrationIncomplete)
                     if syncEnabled {
                         Picker(selection: Binding(
                             get: { storageMode },
@@ -119,6 +122,11 @@ struct EditLibrarySheet: View {
                     }
                     Button(String(localized: "Troubleshooting.FreeUpSpace", table: "More")) {
                         isConfirmingFreeUpSpace = true
+                    }
+                    if migrationIncomplete {
+                        Button(String(localized: "Troubleshooting.FinishMigration", table: "More")) {
+                            Task { await finishMigration() }
+                        }
                     }
                     Button(String(localized: "Troubleshooting.ClearCache", table: "More")) {
                         isConfirmingClearCache = true
@@ -191,6 +199,7 @@ struct EditLibrarySheet: View {
         }
         .task {
             await loadCounts()
+            migrationIncomplete = await !DataActor.instance(for: library.id).isLibraryV2MigrationComplete()
             syncEnabled = await LibrariesActor.shared.isSyncEnabled(id: library.id)
             iCloudAvailable = await SyncManager.shared.canEnableSync()
             storageMode = StorageMode(rawValue: await LibrariesActor.shared.storageMode(forID: library.id))
@@ -364,6 +373,11 @@ struct EditLibrarySheet: View {
                 isRebuildingThumbnails = false
             }
         }
+    }
+
+    func finishMigration() async {
+        await imageMigration.runIfNeeded(for: library.id)
+        migrationIncomplete = await !DataActor.instance(for: library.id).isLibraryV2MigrationComplete()
     }
 
     func freeUpSpace() async {

--- a/Shared/Data Actor/DataActor+ImageMigration.swift
+++ b/Shared/Data Actor/DataActor+ImageMigration.swift
@@ -107,6 +107,25 @@ extension DataActor {
         }
     }
 
+    @discardableResult
+    func purgeMigratedBlobs() -> Int {
+        guard isLibraryV2MigrationComplete() else { return 0 }
+        let query = picsTable
+            .filter(picFilePath != nil && picData != nil)
+            .select(picId)
+        let ids = (try? database.prepare(query).map { $0[picId] }) ?? []
+        var purged = 0
+        for id in ids where verifyMigratedFile(id: id) {
+            do {
+                try database.run(picsTable.filter(picId == id).update(picData <- nil))
+                purged += 1
+            } catch {
+                debugPrint("Failed to purge migrated blob for \(id): \(error)")
+            }
+        }
+        return purged
+    }
+
     // MARK: - Helpers
 
     private func pendingMigrationIDs() -> [String] {

--- a/Shared/Strings/More.xcstrings
+++ b/Shared/Strings/More.xcstrings
@@ -3519,6 +3519,47 @@
         }
       }
     },
+    "Troubleshooting.FinishMigration" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migration abschließen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finish Migration"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移行を完了"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "마이그레이션 완료"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完成迁移"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完成遷移"
+          }
+        }
+      }
+    },
     "Troubleshooting.FreeUpSpace" : {
       "localizations" : {
         "de" : {


### PR DESCRIPTION
## Summary

Improvements around the LibraryV2 image migration (blobs moved from the SQLite `data` column to files on disk) and the **Free Up Space** / sync flows.

## Changes

### 1. Purge unneeded migrated blobs before vacuuming
When a library's migration is already complete, **Free Up Space** now removes leftover redundant blob data *before* vacuuming. A `VACUUM`/`incremental_vacuum` only reclaims pages that are already free, so redundant blob rows still occupying live pages would otherwise never be reclaimed.

- `DataActor.purgeMigratedBlobs()` — no-ops unless the migration is complete. Finds pics that have both a `file_path` and a non-nil `data` blob, verifies the on-disk file is a faithful copy via the existing `verifyMigratedFile(id:)` SHA-256 check, then clears the blob. Pics whose file fails verification (still relying on the blob) are left untouched.
- `freeUpSpace()` calls `purgeMigratedBlobs()` before `reclaimDiskSpace()`.

### 2. "Finish Migration" option
If a library's migration is detected as incomplete, a **Finish Migration** button now appears in the Troubleshooting section (just below Free Up Space). It runs the existing `ImageMigrationManager.runIfNeeded(for:)` flow, reusing the standard full-screen migration progress UI.

### 3. Disable sync until migration completes
The iCloud **Sync** toggle is now disabled while a library's migration is incomplete, since image externalization is a prerequisite for syncing.

`ImageMigrationManager` is now injected into the environment so `EditLibrarySheet` can drive migration; migration completeness is detected in the sheet's `.task` via `DataActor.isLibraryV2MigrationComplete()`.

Added a localized `Troubleshooting.FinishMigration` string (en/de/ja/ko/zh-Hans/zh-Hant).

## Notes

Built/verified by inspection only — no Swift/Xcode toolchain is available in this environment. The change reuses existing helpers and established SwiftUI/SQLite patterns from the surrounding code.

https://claude.ai/code/session_01VtYh3bA7Bx66BKubsAi8tm