### PR TITLE
Fix vacuuming never reclaiming disk space on legacy databases

### DIFF
--- a/Shared/Data Actor/DataActor.swift
+++ b/Shared/Data Actor/DataActor.swift
@@ -30,6 +30,7 @@ actor DataActor {
     nonisolated let collectionID: String
     let database: Connection
     let databaseURL: URL
+    private var isIncrementalAutoVacuumActive: Bool
 
     let albumsTable = Table("albums")
     let picsTable = Table("pics")
@@ -101,6 +102,10 @@ actor DataActor {
             fatalError("Could not open SQLite database: \(error)")
         }
         self.database = database
+        // PRAGMA auto_vacuum reports the requested value immediately, even before
+        // a VACUUM applies it, so read the real mode before requesting the change.
+        let activeAutoVacuumMode = (try? database.scalar("PRAGMA auto_vacuum")) as? Int64 ?? 0
+        self.isIncrementalAutoVacuumActive = activeAutoVacuumMode == 2
         _ = try? database.execute("PRAGMA auto_vacuum = INCREMENTAL;")
         do {
             try database.run(albumsTable.create(ifNotExists: true) { table in
@@ -170,16 +175,17 @@ actor DataActor {
 
     @discardableResult
     func ensureIncrementalAutoVacuum() -> Bool {
-        if autoVacuumMode() == 2 { return true }
-        _ = try? database.execute("PRAGMA auto_vacuum = INCREMENTAL;")
-        // The mode change only takes effect after a full VACUUM.
+        if isIncrementalAutoVacuumActive { return true }
+        // The auto_vacuum = INCREMENTAL requested at init only takes effect once
+        // a full VACUUM rewrites the database into incremental mode.
         guard freeBytesAtDatabaseLocation() > databaseFileSizeBytes() else { return false }
         do {
             try database.vacuum()
         } catch {
             debugPrint("Auto-vacuum conversion VACUUM failed: \(error)")
         }
-        return autoVacuumMode() == 2
+        isIncrementalAutoVacuumActive = autoVacuumMode() == 2
+        return isIncrementalAutoVacuumActive
     }
 
     @discardableResult


### PR DESCRIPTION
## Problem

"Free up space" (and post-migration cleanup) reported success but never actually shrank `Collection.db`.

The reclaim path runs `freeUpSpace()` → `reclaimDiskSpace()` → `ensureIncrementalAutoVacuum()`. That function trusted `PRAGMA auto_vacuum` to tell it whether the database was in incremental mode:

```swift
if autoVacuumMode() == 2 { return true }
```

But SQLite reports the **requested** `auto_vacuum` value immediately, even though the database physically stays in its original `NONE` mode until a full `VACUUM` rewrites it. Because `init` issues `PRAGMA auto_vacuum = INCREMENTAL` on every open, `autoVacuumMode()` always returned `2`, so:

1. `ensureIncrementalAutoVacuum()` short-circuited and **never ran the conversion `VACUUM`**.
2. `reclaimDiskSpace()` then ran `PRAGMA incremental_vacuum`, which is a **no-op** on a database that isn't truly in incremental mode.

Net result: freed pages stayed in the freelist forever and the file never shrank — and `reclaimDiskSpace()` still returned `true`, so nothing was logged.

This affects every library created before incremental auto-vacuum was set at creation time (i.e. the older, blob-heavy libraries that most need reclaiming).

## Fix

- Read the **real** `auto_vacuum` mode at open time, *before* requesting the change, and cache it in `isIncrementalAutoVacuumActive`.
- Gate the incremental path on that cached flag. When the database hasn't actually been converted, `ensureIncrementalAutoVacuum()` now performs the full `VACUUM` (which both converts the mode and reclaims space) and only then marks incremental vacuum as active. Subsequent calls use the cheap incremental path.

https://claude.ai/code/session_01VU8w3ko68aBMksDSuPEtew

---
_Generated by [Claude Code](https://claude.ai/code/session_01VU8w3ko68aBMksDSuPEtew)_