### PR TITLE
Replace thumbnail/space tools with a single Verify Consistency action

### DIFF
--- a/App/Views/Libraries/EditLibrarySheet.swift
+++ b/App/Views/Libraries/EditLibrarySheet.swift
@@ -20,12 +20,10 @@ struct EditLibrarySheet: View {
     @State var backupFolderURL: URL?
     @State var isDuplicateCheckerPresented: Bool = false
 
-    @State var isConfirmingRebuildThumbnails: Bool = false
-    @State var isRebuildingThumbnails: Bool = false
-    @State var rebuildProgress: Int = 0
-    @State var rebuildTotal: Int = 0
-    @State var isConfirmingFreeUpSpace: Bool = false
-    @State var isFreeingUpSpace: Bool = false
+    @State var isConfirmingVerifyConsistency: Bool = false
+    @State var isVerifyingConsistency: Bool = false
+    @State var verifyProgress: Int = 0
+    @State var verifyTotal: Int = 0
     @State var isConfirmingClearCache: Bool = false
     @State var migrationIncomplete: Bool = false
 
@@ -117,11 +115,8 @@ struct EditLibrarySheet: View {
                     Text("Tools", tableName: "More")
                 }
                 Section {
-                    Button(String(localized: "Troubleshooting.RebuildThumbnails", table: "More")) {
-                        isConfirmingRebuildThumbnails = true
-                    }
-                    Button(String(localized: "Troubleshooting.FreeUpSpace", table: "More")) {
-                        isConfirmingFreeUpSpace = true
+                    Button(String(localized: "Troubleshooting.VerifyConsistency", table: "More")) {
+                        isConfirmingVerifyConsistency = true
                     }
                     if migrationIncomplete {
                         Button(String(localized: "Troubleshooting.FinishMigration", table: "More")) {
@@ -253,23 +248,14 @@ struct EditLibrarySheet: View {
         .sheet(isPresented: $isDuplicateCheckerPresented) {
             DuplicateScanView(scanScope: .entireCollection, collectionID: library.id)
         }
-        .alert(Text("Troubleshooting.RebuildThumbnails.Confirm.Title", tableName: "More"),
-               isPresented: $isConfirmingRebuildThumbnails) {
+        .alert(Text("Troubleshooting.VerifyConsistency.Confirm.Title", tableName: "More"),
+               isPresented: $isConfirmingVerifyConsistency) {
             Button("Shared.Yes", role: .destructive) {
-                Task { await rebuildThumbnails() }
+                Task { await verifyConsistency() }
             }
             Button("Shared.No", role: .cancel) { }
         } message: {
-            Text("Troubleshooting.RebuildThumbnails.Confirm.Message", tableName: "More")
-        }
-        .alert(Text("Troubleshooting.FreeUpSpace.Confirm.Title", tableName: "More"),
-               isPresented: $isConfirmingFreeUpSpace) {
-            Button("Shared.Yes", role: .destructive) {
-                Task { await freeUpSpace() }
-            }
-            Button("Shared.No", role: .cancel) { }
-        } message: {
-            Text("Troubleshooting.FreeUpSpace.Confirm.Message", tableName: "More")
+            Text("Troubleshooting.VerifyConsistency.Confirm.Message", tableName: "More")
         }
         .alert(Text("Troubleshooting.ClearCache.Confirm.Title", tableName: "More"),
                isPresented: $isConfirmingClearCache) {
@@ -311,20 +297,15 @@ struct EditLibrarySheet: View {
         } message: {
             Text("Libraries.Delete.Message \(expectedDeleteCode)", tableName: "Libraries")
         }
-        .sheet(isPresented: $isRebuildingThumbnails) {
+        .sheet(isPresented: $isVerifyingConsistency) {
             StatusView(
                 type: .inProgress,
-                title: .troubleshootingRebuildingThumbnails,
-                currentCount: rebuildProgress,
-                totalCount: rebuildTotal
+                title: .troubleshootingVerifyingConsistency,
+                currentCount: verifyTotal > 0 ? verifyProgress : nil,
+                totalCount: verifyTotal > 0 ? verifyTotal : nil
             )
             .phonePresentationDetents([.medium])
             .interactiveDismissDisabled()
-        }
-        .sheet(isPresented: $isFreeingUpSpace) {
-            StatusView(type: .inProgress, title: .troubleshootingFreeingUpSpace)
-                .phonePresentationDetents([.medium])
-                .interactiveDismissDisabled()
         }
     }
 
@@ -338,63 +319,29 @@ struct EditLibrarySheet: View {
         }
     }
 
-    func rebuildThumbnails() async {
-        let dataActor = DataActor(collectionID: library.id)
-        await MainActor.run {
-            UIApplication.shared.isIdleTimerDisabled = true
-            isRebuildingThumbnails = true
-            rebuildProgress = 0
-            rebuildTotal = 0
-        }
-        do {
-            let pics = try await dataActor.pics()
-            await MainActor.run {
-                rebuildTotal = pics.count
-            }
-            await dataActor.deleteAllThumbnails()
-            for pic in pics {
-                if let data = await dataActor.imageData(forPicWithID: pic.id) {
-                    let thumbnailData = Pic.makeThumbnail(data)
-                    await dataActor.updateThumbnail(forPicWithID: pic.id,
-                                                    thumbnailData: thumbnailData)
-                }
-                await MainActor.run {
-                    rebuildProgress += 1
-                }
-            }
-            await MainActor.run {
-                UIApplication.shared.isIdleTimerDisabled = false
-                isRebuildingThumbnails = false
-            }
-        } catch {
-            debugPrint(error.localizedDescription)
-            await MainActor.run {
-                UIApplication.shared.isIdleTimerDisabled = false
-                isRebuildingThumbnails = false
-            }
-        }
-    }
-
     func finishMigration() async {
         await imageMigration.runIfNeeded(for: library.id)
         migrationIncomplete = await !DataActor.instance(for: library.id).isLibraryV2MigrationComplete()
     }
 
-    func freeUpSpace() async {
+    func verifyConsistency() async {
         let dataActor = DataActor(collectionID: library.id)
         await MainActor.run {
             UIApplication.shared.isIdleTimerDisabled = true
-            isFreeingUpSpace = true
+            verifyProgress = 0
+            verifyTotal = 0
+            isVerifyingConsistency = true
         }
-        await dataActor.purgeMigratedBlobs()
-        let reclaimed = await dataActor.reclaimDiskSpace()
-        if !reclaimed {
-            debugPrint("Free up space: no disk space was reclaimed")
+        await dataActor.verifyConsistency { progress in
+            verifyProgress = progress.completed
+            verifyTotal = progress.total
         }
         await MainActor.run {
-            isFreeingUpSpace = false
+            isVerifyingConsistency = false
             UIApplication.shared.isIdleTimerDisabled = false
         }
+        await loadCounts()
+        migrationIncomplete = await !DataActor.instance(for: library.id).isLibraryV2MigrationComplete()
     }
 
     func downloadAll() async {

--- a/App/Views/Shared/StatusView.swift
+++ b/App/Views/Shared/StatusView.swift
@@ -26,8 +26,7 @@ struct StatusView: View {
         // More table
         case backupExporting
         case backupExportCompleted
-        case troubleshootingRebuildingThumbnails
-        case troubleshootingFreeingUpSpace
+        case troubleshootingVerifyingConsistency
         case backupRestoring
         case backupRestoreCompleted
         case backupRestoreError
@@ -49,10 +48,8 @@ struct StatusView: View {
                 Text("Backup.Exporting", tableName: "More")
             case .backupExportCompleted:
                 Text("Backup.Export.Completed", tableName: "More")
-            case .troubleshootingRebuildingThumbnails:
-                Text("Troubleshooting.RebuildThumbnails.Rebuilding", tableName: "More")
-            case .troubleshootingFreeingUpSpace:
-                Text("Troubleshooting.FreeUpSpace.Freeing", tableName: "More")
+            case .troubleshootingVerifyingConsistency:
+                Text("Troubleshooting.VerifyConsistency.Verifying", tableName: "More")
             case .backupRestoring:
                 Text("Backup.Restoring", tableName: "More")
             case .backupRestoreCompleted:

--- a/Shared/Data Actor/DataActor+ImageMigration.swift
+++ b/Shared/Data Actor/DataActor+ImageMigration.swift
@@ -107,9 +107,18 @@ extension DataActor {
         }
     }
 
+    func verifyConsistency(
+        progress: @escaping @MainActor (ImageMigrationProgress) -> Void
+    ) async {
+        await migrateImageBlobsToFiles(progress: progress)
+        purgeMigratedBlobs()
+        await progress(ImageMigrationProgress(phase: .reclaiming, completed: 0,
+                                              total: 0, latestThumbnail: nil))
+        reclaimDiskSpace()
+    }
+
     @discardableResult
     func purgeMigratedBlobs() -> Int {
-        guard isLibraryV2MigrationComplete() else { return 0 }
         let query = picsTable
             .filter(picFilePath != nil && picData != nil)
             .select(picId)

--- a/Shared/Strings/More.xcstrings
+++ b/Shared/Strings/More.xcstrings
@@ -3560,329 +3560,166 @@
         }
       }
     },
-    "Troubleshooting.FreeUpSpace" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Speicherplatz freigeben"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Free Up Space"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "空き領域を増やす"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "공간 확보"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "释放空间"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "釋放空間"
-          }
-        }
-      }
-    },
-    "Troubleshooting.FreeUpSpace.Confirm.Message" : {
+    "Troubleshooting.VerifyConsistency" : {
       "extractionState" : "manual",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Diese Bibliothek wird optimiert, um Speicherplatz freizugeben. Dies kann einige Minuten dauern. Sind Sie sicher?"
+            "value" : "Konsistenz prüfen"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "This will optimize this library to free up space, and may take a few minutes to complete. Are you sure?"
+            "value" : "Verify Consistency"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "このライブラリを最適化して空き領域を増やします。完了までに数分かかる場合があります。よろしいですか？"
+            "value" : "整合性を確認"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "이 라이브러리를 최적화하여 공간을 확보합니다. 완료하는 데 몇 분 정도 걸릴 수 있습니다. 계속하시겠습니까?"
+            "value" : "일관성 확인"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "这将优化此资料库以释放空间，可能需要几分钟才能完成。确定要继续吗？"
+            "value" : "验证一致性"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "這將優化此資料庫以釋放空間，可能需要幾分鐘才能完成。確定要繼續嗎？"
+            "value" : "驗證一致性"
           }
         }
       }
     },
-    "Troubleshooting.FreeUpSpace.Confirm.Title" : {
+    "Troubleshooting.VerifyConsistency.Confirm.Message" : {
       "extractionState" : "manual",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Speicherplatz freigeben"
+            "value" : "Verbleibende Originale werden aus der Datenbank ausgelagert, jede Kopie wird per Hash überprüft und anschließend wird die Datenbank komprimiert, um Speicherplatz freizugeben. Dies kann einige Minuten dauern. Sind Sie sicher?"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Free Up Space"
+            "value" : "This will move any remaining originals out of the database, verify each copy by its hash, then compact the database to free up space. This may take a few minutes to complete. Are you sure?"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "空き容量を増やす"
+            "value" : "データベースに残っているオリジナルをファイルへ移行し、ハッシュで各コピーを検証してから、データベースを最適化して空き領域を増やします。完了までに数分かかる場合があります。よろしいですか？"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "공간 확보"
+            "value" : "데이터베이스에 남아 있는 원본을 파일로 옮기고 해시로 각 사본을 검증한 다음 데이터베이스를 압축하여 공간을 확보합니다. 완료하는 데 몇 분 정도 걸릴 수 있습니다. 계속하시겠습니까?"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "释放空间"
+            "value" : "这会将数据库中剩余的原图移出到文件，通过哈希校验每个副本，然后压缩数据库以释放空间。可能需要几分钟才能完成。确定要继续吗？"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "釋放空間"
+            "value" : "這會將資料庫中剩餘的原圖移出到檔案，透過雜湊校驗每個副本，然後壓縮資料庫以釋放空間。可能需要幾分鐘才能完成。確定要繼續嗎？"
           }
         }
       }
     },
-    "Troubleshooting.FreeUpSpace.Freeing" : {
+    "Troubleshooting.VerifyConsistency.Confirm.Title" : {
       "extractionState" : "manual",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Speicherplatz wird freigegeben …"
+            "value" : "Konsistenz prüfen"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Freeing up disk space..."
+            "value" : "Verify Consistency"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "データベースを最適化中…"
+            "value" : "整合性を確認"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "디스크 공간 확보 중…"
+            "value" : "일관성 확인"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "正在释放磁盘空间…"
+            "value" : "验证一致性"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "正在釋放磁碟空間⋯"
+            "value" : "驗證一致性"
           }
         }
       }
     },
-    "Troubleshooting.RebuildThumbnails" : {
+    "Troubleshooting.VerifyConsistency.Verifying" : {
       "extractionState" : "manual",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Alle Miniaturbilder neu erstellen"
+            "value" : "Konsistenz wird geprüft …"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Recreate All Thumbnails"
+            "value" : "Verifying consistency..."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "すべてのサムネイルを再生成"
+            "value" : "整合性を確認中…"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "모든 썸네일 재생성"
+            "value" : "일관성 확인 중…"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "重新创建所有缩略图"
+            "value" : "正在验证一致性…"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "重新建立所有縮圖"
-          }
-        }
-      }
-    },
-    "Troubleshooting.RebuildThumbnails.Confirm.Message" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alle Miniaturbilder dieser Bibliothek werden neu erstellt. Dies kann einige Minuten dauern. Sind Sie sicher?"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This will regenerate all thumbnails for this library, and may take a few minutes to complete. Are you sure?"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "このライブラリのすべてのサムネイルを再生成します。完了までに数分かかる場合があります。よろしいですか？"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이 라이브러리의 모든 썸네일을 다시 생성합니다. 완료하는 데 몇 분 정도 걸릴 수 있습니다. 계속하시겠습니까?"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "这将重新生成此资料库的所有缩略图，可能需要几分钟才能完成。确定要继续吗？"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "這將重新產生此資料庫的所有縮圖，可能需要幾分鐘才能完成。確定要繼續嗎？"
-          }
-        }
-      }
-    },
-    "Troubleshooting.RebuildThumbnails.Confirm.Title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Miniaturbilder neu erstellen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rebuild Thumbnails"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "サムネイルを再構築"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "썸네일 재생성"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重新创建缩略图"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重新建立縮圖"
-          }
-        }
-      }
-    },
-    "Troubleshooting.RebuildThumbnails.Rebuilding" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Miniaturbilder werden neu erstellt …"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recreating thumbnails..."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "サムネイルを再生成中…"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "썸네일 재생성 중…"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在重新创建缩略图…"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在重新建立縮圖⋯"
+            "value" : "正在驗證一致性⋯"
           }
         }
       }


### PR DESCRIPTION
## Summary

Consolidates the **Recreate All Thumbnails** and **Free Up Space** troubleshooting options into a single **Verify Consistency** action that repairs a library's database end to end.

When run, Verify Consistency:
1. **Migrates** any originals still held as blobs in `Collection.db` out to files.
2. **Removes** each migrated blob only after a SHA-256 hash check confirms the on-disk copy matches byte-for-byte.
3. **Vacuums** the database to actually reclaim the freed space.

## Why

`Collection.db` was staying at its original size after migration. I verified empirically that the SQLite reclaim primitives themselves work (a full `VACUUM` after clearing blobs shrinks a 102 MB file to 32 KB; `incremental_vacuum` via `sqlite3_exec` clears the whole freelist). The real problem is operational: the migration gets marked complete unconditionally, so if a run is interrupted — leaving blobs uncleared or the file uncompacted — there was no automatic path back; the only recovery was the manual button.

Verify Consistency gives users one explicit, idempotent repair that always finishes the job: it re-migrates stragglers, hash-checks before deleting originals, and compacts the file even when there is nothing left to migrate (covering the "blobs already cleared but file never vacuumed" case).

## Changes

- `DataActor+ImageMigration.swift`: add `verifyConsistency(progress:)`; drop the now-unnecessary migration-complete guard in `purgeMigratedBlobs()` (each blob is still individually hash-verified before removal, so it is safe to run anytime).
- `EditLibrarySheet.swift`: replace the two buttons, confirmations, progress sheets, and handlers with the single Verify Consistency flow.
- `StatusView.swift`: replace the two progress titles with one verifying-consistency title.
- `More.xcstrings`: remove the old strings, add localized Verify Consistency strings (en/de/ja/ko/zh-Hans/zh-Hant).

https://claude.ai/code/session_01Ph2ATAPRHmHFWTSyXM6Xnx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ph2ATAPRHmHFWTSyXM6Xnx)_