### PR TITLE
Add document picker to export files from Labs File Explorer

### DIFF
--- a/App/Views/More/LabsFileExplorerView.swift
+++ b/App/Views/More/LabsFileExplorerView.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftUI
+import UIKit
 
 struct LabsFileEntry: Identifiable, Hashable {
 
@@ -74,6 +75,7 @@ private struct LabsFileEntryRow: View {
     @State private var children: [LabsFileEntry] = []
     @State private var isExpanded: Bool = false
     @State private var didLoad: Bool = false
+    @State private var isExportPresented: Bool = false
 
     var body: some View {
         if entry.isDirectory {
@@ -96,19 +98,38 @@ private struct LabsFileEntryRow: View {
                 }
             }
         } else {
-            Label {
-                VStack(alignment: .leading, spacing: 2.0) {
-                    Text(entry.name)
-                    Text(entry.size.formatted(.byteCount(style: .file)))
-                        .font(.caption)
+            Button {
+                isExportPresented = true
+            } label: {
+                Label {
+                    VStack(alignment: .leading, spacing: 2.0) {
+                        Text(entry.name)
+                        Text(entry.size.formatted(.byteCount(style: .file)))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .monospacedDigit()
+                    }
+                } icon: {
+                    Image(systemName: "doc")
                         .foregroundStyle(.secondary)
-                        .monospacedDigit()
                 }
-            } icon: {
-                Image(systemName: "doc")
-                    .foregroundStyle(.secondary)
             }
-            .textSelection(.enabled)
+            .buttonStyle(.plain)
+            .sheet(isPresented: $isExportPresented) {
+                DocumentExporter(url: entry.url)
+                    .ignoresSafeArea()
+            }
         }
     }
+}
+
+private struct DocumentExporter: UIViewControllerRepresentable {
+
+    let url: URL
+
+    func makeUIViewController(context: Context) -> UIDocumentPickerViewController {
+        UIDocumentPickerViewController(forExporting: [url], asCopy: true)
+    }
+
+    func updateUIViewController(_ uiViewController: UIDocumentPickerViewController, context: Context) {}
 }


### PR DESCRIPTION
## Summary

Tapping a file in **More → Labs → File Explorer** now presents a document picker that lets the user copy the file out to another location.

## Changes

- Wrapped each file row in a `Button` that presents a sheet on tap (folders keep their existing expand/collapse behavior).
- Added a `DocumentExporter` (`UIViewControllerRepresentable`) wrapping `UIDocumentPickerViewController(forExporting:asCopy:)`, so the user can choose a destination and the file is copied there.

Since the files live in the app's shared container, no security-scoped resource handling is needed.

https://claude.ai/code/session_01EQveV9vJLS42tioTFrcfne

---
_Generated by [Claude Code](https://claude.ai/code/session_01EQveV9vJLS42tioTFrcfne)_