### PR TITLE
Clear leftover image blobs left behind after migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,6 @@
 # Code style
 
-- If the code is self-explanatory, write no comment at all.
-- Only comment to explain *why* something non-obvious is done (e.g. a
-  surprising API requirement or workaround), never to restate *what* the code
-  does.
-- Verbose comments are disallowed completely. A comment is at most one short
-  line. No multi-line comment blocks, no doc comments, no stacked single-line
-  comments that together form a paragraph.
+- Do not write comments at all, unless it documents an unexpected API
+  requirement or gotcha (e.g. a surprising API behavior or workaround).
+- Never comment to explain *what* the code does, restate logic, or justify a
+  design choice. No multi-line blocks, no doc comments.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,4 +3,7 @@
 - If the code is self-explanatory, write no comment at all.
 - Only comment to explain *why* something non-obvious is done (e.g. a
   surprising API requirement or workaround), never to restate *what* the code
-  does. No multi-line explanatory blocks or doc comments that echo the code.
+  does.
+- Verbose comments are disallowed completely. A comment is at most one short
+  line. No multi-line comment blocks, no doc comments, no stacked single-line
+  comments that together form a paragraph.

--- a/Shared/Data Actor/DataActor+ImageMigration.swift
+++ b/Shared/Data Actor/DataActor+ImageMigration.swift
@@ -26,12 +26,14 @@ extension DataActor {
     }
 
     func isLibraryV2MigrationComplete() -> Bool {
-        if migrationCompletedFlag(Self.libraryV2MigrationName) { return true }
-        guard needsImageMigration() else {
-            markLibraryV2MigrationComplete()
-            return true
-        }
-        return false
+        // The on-disk flag is only a record; the source of truth is whether any
+        // pic blob is still present. Trusting the flag alone left blobs that a
+        // single migration pass failed to clear (verification failure, disk
+        // pressure mid-copy, or a swallowed clear) orphaned forever, since the
+        // migration would never revisit them.
+        guard !needsImageMigration() else { return false }
+        markLibraryV2MigrationComplete()
+        return true
     }
 
     func markLibraryV2MigrationComplete() {
@@ -43,18 +45,18 @@ extension DataActor {
         ))
     }
 
-    private func migrationCompletedFlag(_ name: String) -> Bool {
-        let query = migrationsTable.filter(migrationName == name)
-        guard let row = try? database.pluck(query) else { return false }
-        return (try? row.get(migrationCompleted)) ?? false
-    }
-
     func migrateImageBlobsToFiles(
         progress: @escaping @MainActor (ImageMigrationProgress) -> Void
     ) async {
+        // Clear blobs whose file already exists on disk so leftovers from an
+        // earlier interrupted pass are reclaimed without rewriting their files.
+        let purged = purgeMigratedBlobs()
         let pending = pendingMigrationIDs()
         let total = pending.count
-        guard total > 0 else { return }
+        guard total > 0 else {
+            if purged > 0 { reclaimDiskSpace() }
+            return
+        }
         await progress(ImageMigrationProgress(phase: .copying, completed: 0,
                                               total: total, latestThumbnail: nil))
 

--- a/Shared/Data Actor/DataActor+ImageMigration.swift
+++ b/Shared/Data Actor/DataActor+ImageMigration.swift
@@ -25,7 +25,6 @@ extension DataActor {
     }
 
     func isLibraryV2MigrationComplete() -> Bool {
-        // Leftover blobs, not the one-shot flag, decide completion.
         guard !needsImageMigration() else { return false }
         markLibraryV2MigrationComplete()
         return true
@@ -43,7 +42,6 @@ extension DataActor {
     func migrateImageBlobsToFiles(
         progress: @escaping @MainActor (ImageMigrationProgress) -> Void
     ) async {
-        // Reclaim already-migrated blobs without rewriting their files.
         let purged = purgeMigratedBlobs()
         let pending = pendingMigrationIDs()
         let total = pending.count

--- a/Shared/Data Actor/DataActor+ImageMigration.swift
+++ b/Shared/Data Actor/DataActor+ImageMigration.swift
@@ -1,4 +1,3 @@
-import CryptoKit
 import Foundation
 @preconcurrency import SQLite
 
@@ -169,7 +168,7 @@ extension DataActor {
               let fileData = try? Data(contentsOf: imageFileURL(forRelativePath: path)) else {
             return false
         }
-        return SHA256.hash(data: fileData) == SHA256.hash(data: blob)
+        return fileData == blob
     }
 
     private func chosenBatchSize(total: Int) -> Int {

--- a/Shared/Data Actor/DataActor+ImageMigration.swift
+++ b/Shared/Data Actor/DataActor+ImageMigration.swift
@@ -25,11 +25,7 @@ extension DataActor {
     }
 
     func isLibraryV2MigrationComplete() -> Bool {
-        // The on-disk flag is only a record; the source of truth is whether any
-        // pic blob is still present. Trusting the flag alone left blobs that a
-        // single migration pass failed to clear (verification failure, disk
-        // pressure mid-copy, or a swallowed clear) orphaned forever, since the
-        // migration would never revisit them.
+        // Leftover blobs, not the one-shot flag, decide completion.
         guard !needsImageMigration() else { return false }
         markLibraryV2MigrationComplete()
         return true
@@ -47,8 +43,7 @@ extension DataActor {
     func migrateImageBlobsToFiles(
         progress: @escaping @MainActor (ImageMigrationProgress) -> Void
     ) async {
-        // Clear blobs whose file already exists on disk so leftovers from an
-        // earlier interrupted pass are reclaimed without rewriting their files.
+        // Reclaim already-migrated blobs without rewriting their files.
         let purged = purgeMigratedBlobs()
         let pending = pendingMigrationIDs()
         let total = pending.count


### PR DESCRIPTION
## Problem

Pics that had already been migrated to on-disk files still kept their full `data` BLOB in the database (e.g. a 383 KB TIFF blob sitting next to a valid file). The blobs were never reclaimed even though the migration reported as complete.

## Root cause

The migration *does* clear each pic's blob (`picData <- nil`) — that code has been present since the feature landed. But the clearing is conditional and the whole run is **one-shot**:

- A row is only cleared if it passes byte-for-byte verification in that single pass.
- A verification failure calls `revertMigratedFile`, which deletes the new file and nulls `file_path` but deliberately **keeps** the blob.
- The clear's DB error is swallowed (`catch { debugPrint }`).
- Crucially, once `markLibraryV2MigrationComplete()` writes the flag into the `migrations` table, `isLibraryV2MigrationComplete()` short-circuits to `true` forever (that flag was its only input), so the migration **never revisits** the rows it failed to clear.

So any blob not cleared in that single pass — verification failure, disk pressure mid-copy, or a swallowed clear — is orphaned permanently.

## Fix

- **Make blob presence the source of truth for completion.** `isLibraryV2MigrationComplete()` now reports incomplete whenever `needsImageMigration()` still finds pic blobs, instead of trusting the one-shot flag. Leftovers re-run the migration and get cleared; the flag is kept only as a record. The now-unused `migrationCompletedFlag` helper is removed.
- **Purge already-migrated blobs up front.** `migrateImageBlobsToFiles` now calls `purgeMigratedBlobs()` before copying, so rows whose file already exists on disk are reclaimed directly without rewriting their files, and reclaims disk space if that's all that was needed.

This keeps sync gating consistent (libraries with leftover blobs correctly stay "not complete" until cleaned) and is self-healing: affected installs clean themselves up on the next launch.

https://claude.ai/code/session_01Te8XrB6PU7NtsfzghGY9ip

---
_Generated by [Claude Code](https://claude.ai/code/session_01Te8XrB6PU7NtsfzghGY9ip)_