### PR TITLE
Re-migrate mismatched blobs during consistency verification

### DIFF
--- a/Shared/Data Actor/DataActor+ImageMigration.swift
+++ b/Shared/Data Actor/DataActor+ImageMigration.swift
@@ -118,7 +118,11 @@ extension DataActor {
             .select(picId)
         let ids = (try? database.prepare(query).map { $0[picId] }) ?? []
         var purged = 0
-        for id in ids where verifyMigratedFile(id: id) {
+        for id in ids {
+            if !verifyMigratedFile(id: id) {
+                copyBlobToFile(id: id)
+                guard verifyMigratedFile(id: id) else { continue }
+            }
             do {
                 try database.run(picsTable.filter(picId == id).update(picData <- nil))
                 purged += 1


### PR DESCRIPTION
## Summary

During **Verify Consistency**, `purgeMigratedBlobs()` checks each entry that has both an on-disk file (`picFilePath`) and a retained blob (`picData`). Previously, when the on-disk file's bytes no longer matched the blob, the entry was silently skipped — leaving a corrupt file on disk while keeping the blob around forever.

This change makes verification self-healing: when the file bytes don't match, it re-migrates the data (re-copies the blob to the canonical `Images/{id}` file) and re-verifies the resulting bytes by re-reading from disk. Only if the freshly written file matches is the blob purged; otherwise the blob is retained as before.

## Changes

- `purgeMigratedBlobs()` in `DataActor+ImageMigration.swift`: on a byte mismatch, call `copyBlobToFile(id:)` and re-run `verifyMigratedFile(id:)` before purging.

## Behavior

- Files that already match: unchanged.
- Files that mismatch but re-migrate cleanly: file rewritten, blob purged.
- Files that still mismatch after re-migration: blob retained (no data loss), as before.

https://claude.ai/code/session_01YHFmwWB6zB6tDVe9fzCsiz

---
_Generated by [Claude Code](https://claude.ai/code/session_01YHFmwWB6zB6tDVe9fzCsiz)_