### PR TITLE
Force pics.data column nullable when legacy schema marked it NOT NULL

### DIFF
--- a/Shared/Data Actor/DatabaseMigrator.swift
+++ b/Shared/Data Actor/DatabaseMigrator.swift
@@ -76,8 +76,6 @@ struct DatabaseMigrator {
         _ = try? database.run(preferencesTable.addColumn(prefHideSectionHeaders, defaultValue: false))
     }
 
-    // SQLite cannot drop a NOT NULL constraint via ALTER COLUMN, so older databases that
-    // created "data" as non-null are rebuilt to make image-blob purging possible.
     static func forceNullableImageColumn(_ database: Connection) {
         guard isColumnNotNull("data", inTable: "pics", database) else { return }
         let storedSQL = try? database.scalar(

--- a/Shared/Data Actor/DatabaseMigrator.swift
+++ b/Shared/Data Actor/DatabaseMigrator.swift
@@ -60,6 +60,8 @@ struct DatabaseMigrator {
         _ = try? database.run(picsTable.addColumn(picDuration))
         _ = try? database.run(picsTable.addColumn(picFilePath))
 
+        forceNullableImageColumn(database)
+
         let prefAlbumSort = Expression<String>("album_sort")
         let prefAlbumViewStyle = Expression<String>("album_view_style")
         let prefAlbumColumnCount = Expression<Int>("album_column_count")
@@ -72,6 +74,39 @@ struct DatabaseMigrator {
         _ = try? database.run(preferencesTable.addColumn(prefPicSort, defaultValue: "dateAddedDescending"))
         _ = try? database.run(preferencesTable.addColumn(prefPicColumnCount, defaultValue: 4))
         _ = try? database.run(preferencesTable.addColumn(prefHideSectionHeaders, defaultValue: false))
+    }
+
+    // SQLite cannot drop a NOT NULL constraint via ALTER COLUMN, so older databases that
+    // created "data" as non-null are rebuilt to make image-blob purging possible.
+    static func forceNullableImageColumn(_ database: Connection) {
+        guard isColumnNotNull("data", inTable: "pics", database) else { return }
+        let storedSQL = try? database.scalar(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='pics'"
+        )
+        guard let createSQL = storedSQL as? String,
+              let rebuiltSQL = createSQL.byRemovingNotNull(fromColumn: "data",
+                                                            renamingTableTo: "pics_nullable_migration")
+        else { return }
+        do {
+            try database.transaction {
+                try database.execute(rebuiltSQL)
+                try database.execute("INSERT INTO \"pics_nullable_migration\" SELECT * FROM \"pics\"")
+                try database.execute("DROP TABLE \"pics\"")
+                try database.execute("ALTER TABLE \"pics_nullable_migration\" RENAME TO \"pics\"")
+            }
+        } catch {
+            debugPrint("Failed to force nullable data column: \(error)")
+            _ = try? database.execute("DROP TABLE IF EXISTS \"pics_nullable_migration\"")
+        }
+    }
+
+    private static func isColumnNotNull(_ column: String, inTable table: String,
+                                        _ database: Connection) -> Bool {
+        guard let rows = try? database.prepare("PRAGMA table_info(\(table))") else { return false }
+        for row in rows where (row[1] as? String) == column {
+            return (row[3] as? Int64) == 1
+        }
+        return false
     }
 
     // MARK: - Hashes DB
@@ -112,5 +147,18 @@ struct DatabaseMigrator {
     static func migrateLibrariesDatabase(_ database: Connection, librariesTable: Table) {
         let libraryName = Expression<String>("name")
         _ = try? database.run(librariesTable.addColumn(libraryName, defaultValue: ""))
+    }
+}
+
+private extension String {
+    func byRemovingNotNull(fromColumn column: String, renamingTableTo newName: String) -> String? {
+        guard let tableNameRange = range(of: "\"pics\"") else { return nil }
+        let renamed = replacingCharacters(in: tableNameRange, with: "\"\(newName)\"")
+        let pattern = "(\"\(column)\"\\s+[A-Za-z]+)\\s+NOT\\s+NULL"
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) else {
+            return renamed
+        }
+        let range = NSRange(renamed.startIndex..., in: renamed)
+        return regex.stringByReplacingMatches(in: renamed, range: range, withTemplate: "$1")
     }
 }


### PR DESCRIPTION
## Problem

Some Collection databases — those created by older app versions — defined the `pics.data` column with a `NOT NULL` constraint instead of the current nullable `Expression<Data?>` schema.

The LibraryV2 image migration (`DataActor+ImageMigration.swift`) externalizes each image blob to a file and then clears the in-DB blob with `UPDATE pics SET data = NULL` (`update(picData <- nil)`). Against a `NOT NULL` column this UPDATE fails with a constraint violation, so:

- the blob is never cleared,
- `needsImageMigration()` keeps reporting work pending,
- and the migration can never reclaim disk space.

SQLite cannot drop a `NOT NULL` constraint via `ALTER COLUMN`, so this requires a schema change on the column itself.

## Fix

Added `DatabaseMigrator.forceNullableImageColumn(_:)`, invoked from `migrateCollectionDatabase`:

1. Checks `PRAGMA table_info(pics)` for the `data` column's `notnull` flag — no-op if already nullable, so it's idempotent and safe to run every migration pass.
2. If `NOT NULL`, reads the table's stored `CREATE` statement from `sqlite_master`, renames the table token and strips `NOT NULL` from the `data` column definition.
3. Rebuilds via the standard SQLite table-rebuild procedure inside a transaction: create temp table → `INSERT ... SELECT *` → drop original → rename temp.

Because the new schema is derived from the existing `CREATE` statement, all current columns (including previously-added sync columns), the primary key, and column defaults are preserved. Indexes are recreated by `DataActor.init` as it already does after migration.

https://claude.ai/code/session_01LmauXPWFqzyuAZQuocCPHi

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmauXPWFqzyuAZQuocCPHi)_