### PR TITLE
Include build number in database migration version gate

### DIFF
--- a/Shared/Data Actor/DatabaseMigrator.swift
+++ b/Shared/Data Actor/DatabaseMigrator.swift
@@ -17,17 +17,21 @@ struct DatabaseMigrator {
         defaults?.set(true, forKey: libraryV2CompletedKey)
     }
 
+    static func currentVersionToken() -> String {
+        let short = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0"
+        let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "0"
+        return "\(short) (\(build))"
+    }
+
     static func migrationNeeded() -> Bool {
-        let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0"
         let defaults = UserDefaults(suiteName: appGroupID)
         let migratedVersion = defaults?.string(forKey: migratedVersionKey)
-        return migratedVersion != currentVersion
+        return migratedVersion != currentVersionToken()
     }
 
     static func markMigrationComplete() {
-        let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0"
         let defaults = UserDefaults(suiteName: appGroupID)
-        defaults?.set(currentVersion, forKey: migratedVersionKey)
+        defaults?.set(currentVersionToken(), forKey: migratedVersionKey)
     }
 
     // MARK: - Collection DB (albums + pics + preferences)


### PR DESCRIPTION
## Summary

`DatabaseMigrator.migrationNeeded()` gated migrations purely on `CFBundleShortVersionString` (the marketing version). Builds that share a marketing version but differ in build number — TestFlight betas, CI builds, and hotfixes that bump only `CFBundleVersion` — would see `migratedVersion == currentVersion` and **skip migrations entirely**.

This matters for migration-relevant fixes (e.g. the recent `forceNullableImageColumn` NULL-schema fix in #111): a user on `1.4.2 (1)` would store `"1.4.2"`, and a subsequent `1.4.2 (2)` carrying a migration fix would never run it until the marketing version changed.

## Changes

- Add `currentVersionToken()` combining `CFBundleShortVersionString` and `CFBundleVersion` into a single `"<short> (<build>)"` token.
- Use it symmetrically in both `migrationNeeded()` and `markMigrationComplete()`.

## Notes

- On upgrade, existing installs have `"1.4.2"` stored; the new token `"1.4.2 (47)"` won't match, so migrations re-run **once**. The collection-DB migrations are idempotent (`addColumn` is guarded, `forceNullableImageColumn` no-ops once the column is already nullable), so this is safe.
- The separate LibraryV2 completion flag (a boolean) and the informational `migrationAppVersion` column are unaffected.

https://claude.ai/code/session_0112ePJWBWcz4yVsBwThf95Z

---
_Generated by [Claude Code](https://claude.ai/code/session_0112ePJWBWcz4yVsBwThf95Z)_