### PR TITLE
Prevent deletion of the active library

### DIFF
--- a/App/Views/Libraries/EditLibrarySheet.swift
+++ b/App/Views/Libraries/EditLibrarySheet.swift
@@ -30,6 +30,7 @@ struct EditLibrarySheet: View {
     @State var libraryToDelete: PicLibrary?
     @State var deleteConfirmationCode: String = ""
     @State var expectedDeleteCode: String = ""
+    @State var isShowingActiveLibraryAlert: Bool = false
 
     @State var syncEnabled: Bool = false
     @State var iCloudAvailable: Bool = true
@@ -156,6 +157,10 @@ struct EditLibrarySheet: View {
                 if !library.isDefault {
                     Section {
                         Button(role: .destructive) {
+                            if library.id == libraryManager.currentLibrary.id {
+                                isShowingActiveLibraryAlert = true
+                                return
+                            }
                             expectedDeleteCode = String(format: "%06d", Int.random(in: 0...999_999))
                             deleteConfirmationCode = ""
                             libraryToDelete = library
@@ -296,6 +301,12 @@ struct EditLibrarySheet: View {
             }
         } message: {
             Text("Libraries.Delete.Message \(expectedDeleteCode)", tableName: "Libraries")
+        }
+        .alert(String(localized: "Libraries.Delete.Active.Title", table: "Libraries"),
+               isPresented: $isShowingActiveLibraryAlert) {
+            Button("Shared.OK", role: .cancel) { }
+        } message: {
+            Text("Libraries.Delete.Active.Message", tableName: "Libraries")
         }
         .sheet(isPresented: $isVerifyingConsistency) {
             StatusView(

--- a/Shared/Strings/Libraries.xcstrings
+++ b/Shared/Strings/Libraries.xcstrings
@@ -124,6 +124,88 @@
         }
       }
     },
+    "Libraries.Delete.Active.Message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diese Bibliothek ist derzeit aktiv und kann nicht gelöscht werden. Wechseln Sie zuerst zu einer anderen Bibliothek und versuchen Sie es erneut."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This library is currently active and cannot be deleted. Switch to another library first, then try again."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このライブラリは現在使用中のため削除できません。先に別のライブラリに切り替えてから、もう一度お試しください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 라이브러리는 현재 활성 상태이므로 삭제할 수 없습니다. 먼저 다른 라이브러리로 전환한 후 다시 시도하세요."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此资料库当前处于活跃状态，无法删除。请先切换到其他资料库，然后重试。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此資料庫目前正在使用中，無法刪除。請先切換到其他資料庫，然後再試一次。"
+          }
+        }
+      }
+    },
+    "Libraries.Delete.Active.Title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktive Bibliothek kann nicht gelöscht werden"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cannot Delete Active Library"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用中のライブラリは削除できません"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "활성 라이브러리는 삭제할 수 없음"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法删除活跃资料库"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法刪除使用中的資料庫"
+          }
+        }
+      }
+    },
     "Libraries.Delete.Message %@" : {
       "extractionState" : "manual",
       "localizations" : {


### PR DESCRIPTION
## Summary

Tapping **Delete Library** on the library that is currently active now shows an alert explaining that it cannot be deleted while active, instead of presenting the delete confirmation code prompt. The user must switch to another library first before the deletion flow becomes available.

## Changes

- `EditLibrarySheet.swift`: The Delete Library button now checks whether the library is the current/active library. If so, it presents a blocking alert and returns early rather than starting the delete confirmation flow.
- `Libraries.xcstrings`: Added `Libraries.Delete.Active.Title` and `Libraries.Delete.Active.Message` strings, localized for en, de, ja, ko, zh-Hans, and zh-Hant.

## Testing

This is an iOS/SwiftUI project and cannot be built on the Linux CI host; changes were verified by inspection and JSON validation of the strings catalog.

https://claude.ai/code/session_015sav3bQJe1FZKZdtt8oyYE

---
_Generated by [Claude Code](https://claude.ai/code/session_015sav3bQJe1FZKZdtt8oyYE)_