### PR TITLE
Add hourly background iCloud sync

### DIFF
--- a/App/Classes/OriginalsManager.swift
+++ b/App/Classes/OriginalsManager.swift
@@ -183,6 +183,14 @@ actor OriginalsManager {
         }
     }
 
+    func startAlbumOfflineDownloads(albumID: String, in collectionID: String) async {
+        let ids = await DataActor.instance(for: collectionID).allOriginalPicIDs(inAlbum: albumID)
+        for id in ids {
+            guard let url = cloudURL(forPicID: id, in: collectionID), !isMaterialized(url) else { continue }
+            try? FileManager.default.startDownloadingUbiquitousItem(at: url)
+        }
+    }
+
     func keepAlbumOffline(albumID: String, in collectionID: String) async {
         let allIDs = await DataActor.instance(for: collectionID).allOriginalPicIDs(inAlbum: albumID)
         let pending = allIDs.filter { id in

--- a/App/Classes/SyncManager.swift
+++ b/App/Classes/SyncManager.swift
@@ -81,4 +81,41 @@ final class SyncManager {
             }
         }
     }
+
+    func backgroundSync() async {
+        for id in await LibrariesActor.shared.unmigratedLibraryIDs() {
+            if await DataActor.instance(for: id).isLibraryV2MigrationComplete() {
+                await LibrariesActor.shared.setLibraryMigrated(true, forID: id)
+            }
+        }
+
+        guard await SyncMate.shared.isAccountAvailable() else {
+            await SyncMate.shared.stop()
+            return
+        }
+
+        let enabledIDs = await LibrariesActor.shared.syncEnabledLibraryIDs()
+        await SyncMate.shared.start()
+        await SyncMate.shared.enqueueLibraryChanges()
+        for id in enabledIDs {
+            await SyncMate.shared.enqueueChanges(forLibrary: id)
+        }
+        await SyncMate.shared.fetchChanges()
+        await SyncMate.shared.sendChanges()
+
+        guard !enabledIDs.isEmpty else { return }
+
+        await OriginalsManager.shared.resetSyncStateIfContainerChanged()
+        for id in enabledIDs {
+            await OriginalsManager.shared.uploadMissingOriginals(in: id)
+            await OriginalsManager.shared.reclaimUploadedOriginals(in: id)
+        }
+        for id in await LibrariesActor.shared.downloadAllLibraryIDs() {
+            await OriginalsManager.shared.downloadAllOriginals(in: id)
+        }
+        let enabled = Set(enabledIDs)
+        for (albumID, collectionID) in OfflineAlbums.all() where enabled.contains(collectionID) {
+            await OriginalsManager.shared.startAlbumOfflineDownloads(albumID: albumID, in: collectionID)
+        }
+    }
 }

--- a/App/Info.plist
+++ b/App/Info.plist
@@ -5,6 +5,7 @@
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>com.tsubuzaki.IllustMate.widgetRefresh</string>
+		<string>com.tsubuzaki.IllustMate.iCloudSync</string>
 	</array>
 	<key>CFBundleDocumentTypes</key>
 	<array>

--- a/App/Views/App.swift
+++ b/App/Views/App.swift
@@ -38,6 +38,7 @@ struct IllustMateApp: App {
     ) var lastVersionPromptedForReview: String = ""
 
     nonisolated static let widgetRefreshTaskID = "com.tsubuzaki.IllustMate.widgetRefresh"
+    nonisolated static let iCloudSyncTaskID = "com.tsubuzaki.IllustMate.iCloudSync"
 
     private var mainContent: some View {
         Group {
@@ -254,6 +255,12 @@ struct IllustMateApp: App {
         try? BGTaskScheduler.shared.submit(request)
     }
 
+    nonisolated func scheduleICloudSync() {
+        let request = BGAppRefreshTaskRequest(identifier: IllustMateApp.iCloudSyncTaskID)
+        request.earliestBeginDate = Calendar.current.date(byAdding: .hour, value: 1, to: .now)
+        try? BGTaskScheduler.shared.submit(request)
+    }
+
     var body: some Scene {
         WindowGroup {
             ZStack {
@@ -270,6 +277,7 @@ struct IllustMateApp: App {
                     WidgetCenter.shared.reloadTimelines(ofKind: "Photostand")
                     WidgetCenter.shared.reloadTimelines(ofKind: "PhotoGrid")
                     scheduleWidgetRefresh()
+                    scheduleICloudSync()
                     webServer.stop()
                 }
                 if newValue == .active {
@@ -311,6 +319,10 @@ struct IllustMateApp: App {
             WidgetCenter.shared.reloadTimelines(ofKind: "Photostand")
             WidgetCenter.shared.reloadTimelines(ofKind: "PhotoGrid")
             scheduleWidgetRefresh()
+        }
+        .backgroundTask(.appRefresh(IllustMateApp.iCloudSyncTaskID)) {
+            scheduleICloudSync()
+            await SyncManager.shared.backgroundSync()
         }
 #if targetEnvironment(macCatalyst)
         .commands {


### PR DESCRIPTION
## Summary

Adds a periodic (hourly) background task that runs iCloud sync without blocking on downloads.

- Registers a new `BGAppRefreshTask` (`com.tsubuzaki.IllustMate.iCloudSync`) that reschedules itself with `earliestBeginDate` = +1h on each run and is submitted when the app backgrounds, mirroring the existing widget-refresh pattern.
- `SyncManager.backgroundSync()` awaits the database work — CloudKit `enqueueLibraryChanges` → per-library `enqueueChanges` → `fetchChanges` → `sendChanges`, plus originals upload/reclaim — then only *triggers* file downloads and returns, rather than waiting for them to materialize.
- `OriginalsManager.startAlbumOfflineDownloads(albumID:in:)` kicks off `startDownloadingUbiquitousItem` for an offline album's pics without awaiting (unlike `keepAlbumOffline`, which waits per file and is unsuitable for a time-boxed background task).
- Added the new identifier to `BGTaskSchedulerPermittedIdentifiers` in Info.plist. `UIBackgroundModes` already includes `fetch`, so no entitlement change was needed.

## Notes

- iOS treats `earliestBeginDate` as a floor and throttles app-refresh tasks by usage, so "hourly" is the requested cadence, not a guarantee.

## Testing

- `xcodebuild -scheme PicMate -destination 'generic/platform=iOS Simulator' build` → **BUILD SUCCEEDED**

🤖 Generated with [Claude Code](https://claude.com/claude-code)