### PR TITLE
Add Mac Catalyst option to open pics in separate windows

### DIFF
--- a/App/Views/Album/AlbumView/AlbumView+UserActions.swift
+++ b/App/Views/Album/AlbumView/AlbumView+UserActions.swift
@@ -171,7 +171,16 @@ extension AlbumView {
                     navigation.push(.picViewer(namespace: namespace), for: .collection)
                 }
             } else {
+#if targetEnvironment(macCatalyst)
+                if openPicsInNewWindow {
+                    openWindow(value: ViewerWindowValue.pic(
+                        selectedID: picCopy.id, siblingIDs: pics.map(\.id)))
+                } else {
+                    viewer.setDisplay(picCopy, in: pics) { }
+                }
+#else
                 viewer.setDisplay(picCopy, in: pics) { }
+#endif
             }
         }
     }

--- a/App/Views/Album/AlbumView/AlbumView.swift
+++ b/App/Views/Album/AlbumView/AlbumView.swift
@@ -8,9 +8,13 @@ struct AlbumView: View {
 
     @Environment(\.colorScheme) var colorScheme
     @Environment(\.scenePhase) var scenePhase
+    @Environment(\.openWindow) var openWindow
     @EnvironmentObject var navigation: NavigationManager
     @EnvironmentObject var libraryManager: LibraryManager
     @Environment(ViewerManager.self) var viewer
+
+    @AppStorage(openPicsInNewWindowKey,
+                store: UserDefaults(suiteName: "group.com.tsubuzaki.IllustMate")) var openPicsInNewWindow: Bool = false
 
     @Namespace var namespace
 

--- a/App/Views/App.swift
+++ b/App/Views/App.swift
@@ -327,21 +327,7 @@ struct IllustMateApp: App {
         }
 #if targetEnvironment(macCatalyst)
         .commands {
-            CommandGroup(after: .sidebar) {
-                Button("Command.PreviousPic") {
-                    viewer.navigateToPrevious()
-                    photosViewer.navigateToPrevious()
-                }
-                .keyboardShortcut(.leftArrow, modifiers: .command)
-                .disabled(!viewer.hasPrevious && !photosViewer.hasPrevious)
-
-                Button("Command.NextPic") {
-                    viewer.navigateToNext()
-                    photosViewer.navigateToNext()
-                }
-                .keyboardShortcut(.rightArrow, modifiers: .command)
-                .disabled(!viewer.hasNext && !photosViewer.hasNext)
-            }
+            MacCommands(viewer: viewer, photosViewer: photosViewer)
         }
 #endif
 #if targetEnvironment(macCatalyst)
@@ -358,6 +344,55 @@ struct IllustMateApp: App {
                     .environment(imageMigration)
             }
         }
+
+        WindowGroup("ViewTitle.More", id: settingsWindowID) {
+            MoreView()
+                .environmentObject(navigation)
+                .environmentObject(libraryManager)
+                .environment(viewer)
+                .environment(concurrency)
+                .environment(photosManager)
+                .environment(photosViewer)
+                .environment(auth)
+                .environment(pipManager)
+                .environment(webServer)
+                .environment(imageMigration)
+        }
+        .defaultSize(width: 540.0, height: 640.0)
 #endif
     }
 }
+
+#if targetEnvironment(macCatalyst)
+struct MacCommands: Commands {
+
+    var viewer: ViewerManager
+    var photosViewer: PhotosViewerManager
+
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some Commands {
+        CommandGroup(replacing: .appSettings) {
+            Button("ViewTitle.More") {
+                openWindow(id: settingsWindowID)
+            }
+            .keyboardShortcut(",", modifiers: .command)
+        }
+        CommandGroup(after: .sidebar) {
+            Button("Command.PreviousPic") {
+                viewer.navigateToPrevious()
+                photosViewer.navigateToPrevious()
+            }
+            .keyboardShortcut(.leftArrow, modifiers: .command)
+            .disabled(!viewer.hasPrevious && !photosViewer.hasPrevious)
+
+            Button("Command.NextPic") {
+                viewer.navigateToNext()
+                photosViewer.navigateToNext()
+            }
+            .keyboardShortcut(.rightArrow, modifiers: .command)
+            .disabled(!viewer.hasNext && !photosViewer.hasNext)
+        }
+    }
+}
+#endif

--- a/App/Views/App.swift
+++ b/App/Views/App.swift
@@ -344,5 +344,20 @@ struct IllustMateApp: App {
             }
         }
 #endif
+#if targetEnvironment(macCatalyst)
+        WindowGroup(for: ViewerWindowValue.self) { $value in
+            if let value {
+                ViewerWindowContent(value: value)
+                    .environmentObject(navigation)
+                    .environmentObject(libraryManager)
+                    .environment(concurrency)
+                    .environment(photosManager)
+                    .environment(auth)
+                    .environment(pipManager)
+                    .environment(webServer)
+                    .environment(imageMigration)
+            }
+        }
+#endif
     }
 }

--- a/App/Views/MainSplitView.swift
+++ b/App/Views/MainSplitView.swift
@@ -148,11 +148,13 @@ struct MainSplitView: View {
                             }
                         }
                     }
+#if !targetEnvironment(macCatalyst)
                     Button {
                         isMoreViewPresenting = true
                     } label: {
                         Label("ViewTitle.More", systemImage: "ellipsis")
                     }
+#endif
                 }
                 if isPhotosModeEnabled {
                     Section {

--- a/App/Views/MainSplitView.swift
+++ b/App/Views/MainSplitView.swift
@@ -21,9 +21,102 @@ struct MainSplitView: View {
     @State var isMoreViewPresenting: Bool = false
     @State var isLibraryManagerPresented: Bool = false
 
+    @AppStorage(openPicsInNewWindowKey,
+                store: UserDefaults(suiteName: "group.com.tsubuzaki.IllustMate")) var openPicsInNewWindow: Bool = false
+
     var body: some View {
+        splitView
+        .task {
+            if isPhotosModeEnabled {
+                photosItems = photosManager.fetchTopLevelCollections()
+            } else {
+                do {
+                    albums = try await DataActor.shared.albumsWithCounts(in: nil, sortedBy: .nameAscending)
+                    await AlbumCoverCache.shared.loadCovers(for: albums)
+                } catch {
+                    debugPrint(error.localizedDescription)
+                }
+            }
+        }
+        .onChange(of: isPhotosModeEnabled) { _, newValue in
+            selectedView = .collection
+            if newValue {
+                photosItems = photosManager.fetchTopLevelCollections()
+            } else {
+                photosItems = []
+                Task {
+                    do {
+                        albums = try await DataActor.shared.albumsWithCounts(in: nil, sortedBy: .nameAscending)
+                        await AlbumCoverCache.shared.loadCovers(for: albums)
+                    } catch {
+                        debugPrint(error.localizedDescription)
+                    }
+                }
+            }
+        }
+        .onChange(of: navigation.dataVersion) { _, _ in
+            albums = []
+            selectedView = .collection
+            viewer.displayedPic = nil
+            viewer.displayedImage = nil
+            viewer.displayedThumbnail = nil
+            viewer.allPics = []
+            Task {
+                if isPhotosModeEnabled {
+                    photosItems = photosManager.fetchTopLevelCollections()
+                } else {
+                    do {
+                        albums = try await DataActor.shared.albumsWithCounts(in: nil, sortedBy: .nameAscending)
+                        await AlbumCoverCache.shared.loadCovers(for: albums)
+                    } catch {
+                        debugPrint(error.localizedDescription)
+                    }
+                }
+            }
+        }
+        .sheet(isPresented: $isMoreViewPresenting) {
+            MoreView()
+        }
+        .sheet(isPresented: $isLibraryManagerPresented) {
+            LibraryManagerSheet()
+                .environmentObject(libraryManager)
+                .environmentObject(navigation)
+                .environment(concurrency)
+                .environment(imageMigration)
+        }
+    }
+
+    @ViewBuilder var splitView: some View {
+#if targetEnvironment(macCatalyst)
+        if openPicsInNewWindow {
+            NavigationSplitView {
+                sidebar
+                    .navigationSplitViewColumnWidth(min: 150.0, ideal: 200.0, max: 250.0)
+            } detail: {
+                content
+            }
+        } else {
+            threeColumnSplit
+        }
+#else
+        threeColumnSplit
+#endif
+    }
+
+    @ViewBuilder var threeColumnSplit: some View {
         NavigationSplitView {
-            List(selection: $selectedView) {
+            sidebar
+                .navigationSplitViewColumnWidth(min: 150.0, ideal: 200.0, max: 250.0)
+        } content: {
+            content
+                .navigationSplitViewColumnWidth(min: 300.0, ideal: 375.0, max: 500.0)
+        } detail: {
+            detail
+        }
+    }
+
+    var sidebar: some View {
+        List(selection: $selectedView) {
                 Section {
                     LibrarySwitcherMenu(
                         isLibraryManagerPresented: $isLibraryManagerPresented
@@ -106,109 +199,52 @@ struct MainSplitView: View {
                     }
                 }
             }
-            .navigationSplitViewColumnWidth(min: 150.0, ideal: 200.0, max: 250.0)
-        } content: {
-            Group {
-                switch selectedView {
-                case .collection: CollectionView()
-                case .albums: AlbumsView()
-                case .pics: PicsView()
-                case .album(let album): AlbumNavigationStack(album: album)
-                case .photosAlbum(let wrapper):
-                    NavigationStack {
-                        PhotosAlbumContentView(collection: wrapper.collection)
-                    }
-                case .photosFolder(let wrapper):
-                    NavigationStack {
-                        PhotosFolderView(folder: wrapper.collectionList)
-                            .navigationDestination(for: ViewPath.self) { viewPath in
-                                switch viewPath {
-                                case .photosFolder(let innerWrapper):
-                                    PhotosFolderView(folder: innerWrapper.collectionList)
-                                case .photosAlbum(let innerWrapper):
-                                    PhotosAlbumContentView(collection: innerWrapper.collection)
-                                default: Color.clear
-                                }
+        }
+
+    var content: some View {
+        Group {
+            switch selectedView {
+            case .collection: CollectionView()
+            case .albums: AlbumsView()
+            case .pics: PicsView()
+            case .album(let album): AlbumNavigationStack(album: album)
+            case .photosAlbum(let wrapper):
+                NavigationStack {
+                    PhotosAlbumContentView(collection: wrapper.collection)
+                }
+            case .photosFolder(let wrapper):
+                NavigationStack {
+                    PhotosFolderView(folder: wrapper.collectionList)
+                        .navigationDestination(for: ViewPath.self) { viewPath in
+                            switch viewPath {
+                            case .photosFolder(let innerWrapper):
+                                PhotosFolderView(folder: innerWrapper.collectionList)
+                            case .photosAlbum(let innerWrapper):
+                                PhotosAlbumContentView(collection: innerWrapper.collection)
+                            default: Color.clear
                             }
-                    }
-                default: Color.clear
+                        }
                 }
+            default: Color.clear
             }
-            .navigationSplitViewColumnWidth(min: 300.0, ideal: 375.0, max: 500.0)
-        } detail: {
-            if isPhotosModeEnabled {
-                if let asset = photosViewer.displayedAsset {
-                    PhotosAssetViewer(asset: asset)
-                        .id(asset.localIdentifier)
-                } else {
-                    ContentUnavailableView("Shared.SelectAPhoto", systemImage: "photo.on.rectangle.angled")
-                }
+        }
+    }
+
+    @ViewBuilder var detail: some View {
+        if isPhotosModeEnabled {
+            if let asset = photosViewer.displayedAsset {
+                PhotosAssetViewer(asset: asset)
+                    .id(asset.localIdentifier)
             } else {
-                if let pic = viewer.displayedPic {
-                    PicViewer(pic: pic)
-                        .id(pic.id)
-                } else {
-                    ContentUnavailableView("Shared.SelectAPic", systemImage: "photo.on.rectangle.angled")
-                }
+                ContentUnavailableView("Shared.SelectAPhoto", systemImage: "photo.on.rectangle.angled")
             }
-        }
-        .task {
-            if isPhotosModeEnabled {
-                photosItems = photosManager.fetchTopLevelCollections()
+        } else {
+            if let pic = viewer.displayedPic {
+                PicViewer(pic: pic)
+                    .id(pic.id)
             } else {
-                do {
-                    albums = try await DataActor.shared.albumsWithCounts(in: nil, sortedBy: .nameAscending)
-                    await AlbumCoverCache.shared.loadCovers(for: albums)
-                } catch {
-                    debugPrint(error.localizedDescription)
-                }
+                ContentUnavailableView("Shared.SelectAPic", systemImage: "photo.on.rectangle.angled")
             }
-        }
-        .onChange(of: isPhotosModeEnabled) { _, newValue in
-            selectedView = .collection
-            if newValue {
-                photosItems = photosManager.fetchTopLevelCollections()
-            } else {
-                photosItems = []
-                Task {
-                    do {
-                        albums = try await DataActor.shared.albumsWithCounts(in: nil, sortedBy: .nameAscending)
-                        await AlbumCoverCache.shared.loadCovers(for: albums)
-                    } catch {
-                        debugPrint(error.localizedDescription)
-                    }
-                }
-            }
-        }
-        .onChange(of: navigation.dataVersion) { _, _ in
-            albums = []
-            selectedView = .collection
-            viewer.displayedPic = nil
-            viewer.displayedImage = nil
-            viewer.displayedThumbnail = nil
-            viewer.allPics = []
-            Task {
-                if isPhotosModeEnabled {
-                    photosItems = photosManager.fetchTopLevelCollections()
-                } else {
-                    do {
-                        albums = try await DataActor.shared.albumsWithCounts(in: nil, sortedBy: .nameAscending)
-                        await AlbumCoverCache.shared.loadCovers(for: albums)
-                    } catch {
-                        debugPrint(error.localizedDescription)
-                    }
-                }
-            }
-        }
-        .sheet(isPresented: $isMoreViewPresenting) {
-            MoreView()
-        }
-        .sheet(isPresented: $isLibraryManagerPresented) {
-            LibraryManagerSheet()
-                .environmentObject(libraryManager)
-                .environmentObject(navigation)
-                .environment(concurrency)
-                .environment(imageMigration)
         }
     }
 }

--- a/App/Views/More/MoreView.swift
+++ b/App/Views/More/MoreView.swift
@@ -16,6 +16,8 @@ struct MoreView: View {
                 store: UserDefaults(suiteName: "group.com.tsubuzaki.IllustMate")) var quickImport: Bool = false
     @AppStorage("ShareSheetDefaultAlbum",
                 store: UserDefaults(suiteName: "group.com.tsubuzaki.IllustMate")) var defaultAlbumID: String = ""
+    @AppStorage(openPicsInNewWindowKey,
+                store: UserDefaults(suiteName: "group.com.tsubuzaki.IllustMate")) var openPicsInNewWindow: Bool = false
 
     @State var allAlbums: [Album] = []
 
@@ -60,6 +62,15 @@ struct MoreView: View {
                     Text("ShareSheet.QuickImport.Description", tableName: "More")
                 }
             }
+            #if targetEnvironment(macCatalyst)
+            Section {
+                Toggle(String(localized: "Window.OpenPicsInNewWindow", table: "More"), isOn: $openPicsInNewWindow)
+            } header: {
+                Text("Window", tableName: "More")
+            } footer: {
+                Text("Window.OpenPicsInNewWindow.Description", tableName: "More")
+            }
+            #endif
             WebServerView()
             #if DEBUG
             Section {

--- a/App/Views/More/MoreView.swift
+++ b/App/Views/More/MoreView.swift
@@ -117,11 +117,13 @@ struct MoreView: View {
         NavigationStack(path: $navigation.moreTabPath) {
             listContent
                 .toolbar {
+#if !targetEnvironment(macCatalyst)
                     ToolbarItem(placement: .topBarTrailing) {
                         Button(role: .close) {
                             dismiss()
                         }
                     }
+#endif
                 }
         }
         .task {

--- a/App/Views/More/MoreView.swift
+++ b/App/Views/More/MoreView.swift
@@ -1,5 +1,7 @@
 import SwiftUI
 
+let settingsWindowID = "settings"
+
 struct MoreView: View {
 
     @Environment(\.dismiss) var dismiss

--- a/App/Views/More/MoreView.swift
+++ b/App/Views/More/MoreView.swift
@@ -33,6 +33,15 @@ struct MoreView: View {
             } footer: {
                 Text("AppLock.Description", tableName: "More")
             }
+            #if targetEnvironment(macCatalyst)
+            Section {
+                Toggle(String(localized: "Window.OpenPicsInNewWindow", table: "More"), isOn: $openPicsInNewWindow)
+            } header: {
+                Text("MacApp", tableName: "More")
+            } footer: {
+                Text("Window.OpenPicsInNewWindow.Description", tableName: "More")
+            }
+            #endif
             Section {
                 Toggle(String(localized: "ShareSheet.OpenSearch", table: "More"), isOn: $openSearchWhenSharing)
                 Toggle(String(localized: "ShareSheet.ShowAnimation", table: "More"), isOn: $showAnimationWhenSaving)
@@ -64,15 +73,6 @@ struct MoreView: View {
                     Text("ShareSheet.QuickImport.Description", tableName: "More")
                 }
             }
-            #if targetEnvironment(macCatalyst)
-            Section {
-                Toggle(String(localized: "Window.OpenPicsInNewWindow", table: "More"), isOn: $openPicsInNewWindow)
-            } header: {
-                Text("Window", tableName: "More")
-            } footer: {
-                Text("Window.OpenPicsInNewWindow.Description", tableName: "More")
-            }
-            #endif
             WebServerView()
             #if DEBUG
             Section {

--- a/App/Views/Photos/PhotosAssetsGrid.swift
+++ b/App/Views/Photos/PhotosAssetsGrid.swift
@@ -7,11 +7,14 @@ struct PhotosAssetsGrid: View {
     var assets: [PHAsset]
 
     @Environment(PhotosViewerManager.self) var photosViewer
+    @Environment(\.openWindow) var openWindow
 
     private let batchSize = 200
 
     @AppStorage(wrappedValue: 4, "PicColumnCount",
                 store: UserDefaults(suiteName: "group.com.tsubuzaki.IllustMate")) var columnCount: Int
+    @AppStorage(openPicsInNewWindowKey,
+                store: UserDefaults(suiteName: "group.com.tsubuzaki.IllustMate")) var openPicsInNewWindow: Bool = false
 
     @State private var displayCount: Int = 200
 
@@ -28,7 +31,17 @@ struct PhotosAssetsGrid: View {
                 Group {
                     if UIDevice.current.userInterfaceIdiom == .pad {
                         Button {
+#if targetEnvironment(macCatalyst)
+                            if openPicsInNewWindow {
+                                openWindow(value: ViewerWindowValue.photo(
+                                    selectedID: asset.localIdentifier,
+                                    siblingIDs: assets.map(\.localIdentifier)))
+                            } else {
+                                photosViewer.setDisplay(asset, in: assets)
+                            }
+#else
                             photosViewer.setDisplay(asset, in: assets)
+#endif
                         } label: {
                             PhotosAssetLabel(asset: asset)
                         }
@@ -74,11 +87,14 @@ struct PhotosFetchResultAssetsGrid: View {
     var fetchResult: PHFetchResult<PHAsset>
 
     @Environment(PhotosViewerManager.self) var photosViewer
+    @Environment(\.openWindow) var openWindow
 
     private let batchSize = 200
 
     @AppStorage(wrappedValue: 4, "PicColumnCount",
                 store: UserDefaults(suiteName: "group.com.tsubuzaki.IllustMate")) var columnCount: Int
+    @AppStorage(openPicsInNewWindowKey,
+                store: UserDefaults(suiteName: "group.com.tsubuzaki.IllustMate")) var openPicsInNewWindow: Bool = false
 
     @State private var displayedAssets: [PHAsset] = []
 
@@ -95,7 +111,17 @@ struct PhotosFetchResultAssetsGrid: View {
                 Group {
                     if UIDevice.current.userInterfaceIdiom == .pad {
                         Button {
+#if targetEnvironment(macCatalyst)
+                            if openPicsInNewWindow {
+                                openWindow(value: ViewerWindowValue.photo(
+                                    selectedID: asset.localIdentifier,
+                                    siblingIDs: displayedAssets.map(\.localIdentifier)))
+                            } else {
+                                photosViewer.setDisplay(asset, in: displayedAssets)
+                            }
+#else
                             photosViewer.setDisplay(asset, in: displayedAssets)
+#endif
                         } label: {
                             PhotosAssetLabel(asset: asset)
                         }

--- a/App/Views/Pics/PicsView.swift
+++ b/App/Views/Pics/PicsView.swift
@@ -3,8 +3,12 @@ import SwiftUI
 struct PicsView: View {
 
     @Environment(\.scenePhase) var scenePhase
+    @Environment(\.openWindow) var openWindow
     @EnvironmentObject var navigation: NavigationManager
     @Environment(ViewerManager.self) var viewer
+
+    @AppStorage(openPicsInNewWindowKey,
+                store: UserDefaults(suiteName: "group.com.tsubuzaki.IllustMate")) var openPicsInNewWindow: Bool = false
 
     @Namespace var namespace
 
@@ -25,7 +29,16 @@ struct PicsView: View {
                                 navigation.push(.picViewer(namespace: namespace), for: .pics)
                             }
                         } else {
+#if targetEnvironment(macCatalyst)
+                            if openPicsInNewWindow {
+                                openWindow(value: ViewerWindowValue.pic(
+                                    selectedID: pic.id, siblingIDs: pics.map(\.id)))
+                            } else {
+                                viewer.setDisplay(pic, in: pics) { }
+                            }
+#else
                             viewer.setDisplay(pic, in: pics) { }
+#endif
                         }
                     } selectedCount: {
                         return 0

--- a/App/Views/Viewer/ViewerWindow.swift
+++ b/App/Views/Viewer/ViewerWindow.swift
@@ -1,0 +1,72 @@
+import Photos
+import SwiftUI
+
+let openPicsInNewWindowKey = "OpenPicsInNewWindow"
+
+enum ViewerWindowValue: Codable, Hashable {
+    case pic(selectedID: String, siblingIDs: [String])
+    case photo(selectedID: String, siblingIDs: [String])
+}
+
+struct ViewerWindowContent: View {
+
+    let value: ViewerWindowValue
+
+    @State private var viewer = ViewerManager()
+    @State private var photosViewer = PhotosViewerManager()
+    @State private var hasLoaded: Bool = false
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                switch value {
+                case .pic:
+                    if let pic = viewer.displayedPic {
+                        PicViewer(pic: pic)
+                            .id(pic.id)
+                    } else {
+                        ProgressView()
+                    }
+                case .photo:
+                    if let asset = photosViewer.displayedAsset {
+                        PhotosAssetViewer(asset: asset)
+                            .id(asset.localIdentifier)
+                    } else {
+                        ProgressView()
+                    }
+                }
+            }
+        }
+        .environment(viewer)
+        .environment(photosViewer)
+        .task {
+            await load()
+        }
+    }
+
+    private func load() async {
+        guard !hasLoaded else { return }
+        hasLoaded = true
+        switch value {
+        case let .pic(selectedID, siblingIDs):
+            guard let pics = try? await DataActor.shared.pics(withIDs: siblingIDs),
+                  let selected = pics.first(where: { $0.id == selectedID }) ?? pics.first else { return }
+            viewer.setDisplay(selected, in: pics) { }
+        case let .photo(selectedID, siblingIDs):
+            let assets = Self.fetchAssets(withLocalIdentifiers: siblingIDs)
+            guard let selected = assets.first(where: { $0.localIdentifier == selectedID }) ?? assets.first
+            else { return }
+            photosViewer.setDisplay(selected, in: assets)
+        }
+    }
+
+    private static func fetchAssets(withLocalIdentifiers ids: [String]) -> [PHAsset] {
+        guard !ids.isEmpty else { return [] }
+        let result = PHAsset.fetchAssets(withLocalIdentifiers: ids, options: nil)
+        var byID: [String: PHAsset] = [:]
+        result.enumerateObjects { asset, _, _ in
+            byID[asset.localIdentifier] = asset
+        }
+        return ids.compactMap { byID[$0] }
+    }
+}

--- a/Shared/Data Actor/DataActor+Pics.swift
+++ b/Shared/Data Actor/DataActor+Pics.swift
@@ -31,6 +31,16 @@ extension DataActor {
         return try database.safeRows(orderedQuery).map { picFrom(row: $0) }
     }
 
+    func pics(withIDs ids: [String]) throws -> [Pic] {
+        guard !ids.isEmpty else { return [] }
+        let query = picsTable
+            .filter(ids.contains(picId))
+            .select(picListColumns)
+        let fetched = try database.safeRows(query).map { picFrom(row: $0) }
+        let byID = Dictionary(fetched.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+        return ids.compactMap { byID[$0] }
+    }
+
     func picSkeletons(in album: Album?, order: SortOrder) throws -> [Pic] {
         let baseQuery: SQLite.Table
         if let albumID = album?.id {

--- a/Shared/Strings/More.xcstrings
+++ b/Shared/Strings/More.xcstrings
@@ -1,6 +1,39 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "Window" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Window"
+          }
+        }
+      }
+    },
+    "Window.OpenPicsInNewWindow" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open Pics in New Window"
+          }
+        }
+      }
+    },
+    "Window.OpenPicsInNewWindow.Description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hide the viewer pane in the main window and open each picture in its own window instead."
+          }
+        }
+      }
+    },
     "Advanced" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Shared/Strings/More.xcstrings
+++ b/Shared/Strings/More.xcstrings
@@ -1,43 +1,43 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-    "Window" : {
+    "MacApp" : {
       "extractionState" : "manual",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Fenster"
+            "value" : "Mac-App"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Window"
+            "value" : "Mac App"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ウインドウ"
+            "value" : "Macアプリ"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "윈도우"
+            "value" : "Mac 앱"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "窗口"
+            "value" : "Mac 应用"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "視窗"
+            "value" : "Mac App"
           }
         }
       }

--- a/Shared/Strings/More.xcstrings
+++ b/Shared/Strings/More.xcstrings
@@ -4,10 +4,40 @@
     "Window" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fenster"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Window"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ウインドウ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "윈도우"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "窗口"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "視窗"
           }
         }
       }
@@ -15,10 +45,40 @@
     "Window.OpenPicsInNewWindow" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bilder in neuem Fenster öffnen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Open Pics in New Window"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "画像を新しいウインドウで開く"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "새 윈도우에서 사진 열기"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在新窗口中打开图片"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在新視窗中開啟圖片"
           }
         }
       }
@@ -26,10 +86,40 @@
     "Window.OpenPicsInNewWindow.Description" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Blendet den Vorschaubereich im Hauptfenster aus und öffnet jedes Bild stattdessen in einem eigenen Fenster."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hide the viewer pane in the main window and open each picture in its own window instead."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メインウインドウのビューアを非表示にし、各画像を個別のウインドウで開きます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "메인 윈도우의 뷰어 영역을 숨기고 각 사진을 개별 윈도우에서 엽니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隐藏主窗口中的查看器面板，改为在独立窗口中打开每张图片。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隱藏主視窗中的檢視器面板，改為在獨立視窗中開啟每張圖片。"
           }
         }
       }


### PR DESCRIPTION
## Summary

Adds an opt-in Mac Catalyst feature that hides the `NavigationSplitView` detail pane and opens each picture in its own window.

- **New setting** (`MoreView`): a Mac-only "Open Pics in New Window" toggle (`OpenPicsInNewWindow`, default off), preserving existing inline-detail behavior until opted in.
- **Hiding the detail pane** (`MainSplitView`): refactored the body into reusable `sidebar`/`content`/`detail` view builders. When enabled (Catalyst only), it renders a two-column split (sidebar + content), dropping the detail area; otherwise it falls back to the original three-column layout on every platform.
- **New window per pic** (`ViewerWindow.swift`): a `ViewerWindowValue` enum (`.pic` / `.photo`, carrying selected ID + ordered sibling IDs) drives a `WindowGroup(for:)` scene. Each window owns its own `ViewerManager`/`PhotosViewerManager`, reloads its siblings, and shows `PicViewer`/`PhotosAssetViewer` with working ←/→ navigation.
- **Tap routing**: when enabled, the non-phone tap handlers in `PicsView`, `AlbumView`, and both grids in `PhotosAssetsGrid` call `openWindow(value:)` instead of populating the shared detail viewer.
- **Data**: added `DataActor.pics(withIDs:)`, returning pics in requested order to faithfully reconstruct each window's sibling list.

## Notes
- Windows are keyed by value: tapping a different pic opens a new window; re-tapping the same one focuses the existing window.
- Global Cmd+←/→ menu commands still drive the main window's viewer; per-pic windows navigate via their own focusable arrow-key handling.
- New `More.xcstrings` strings are English-only for now (other locales fall back to English).

## Testing
- Builds cleanly for Mac Catalyst (`xcodebuild -scheme PicMate -destination 'platform=macOS,variant=Mac Catalyst'`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)