### PR TITLE
Sort by primary, accent, and contrasting thumbnail colors

### DIFF
--- a/App/Utilities/ProminentColor.swift
+++ b/App/Utilities/ProminentColor.swift
@@ -3,10 +3,10 @@ import UIKit
 enum ProminentColor {
 
     // swiftlint:disable function_body_length
-    /// Calculates the most prominent color from thumbnail image data.
-    /// White, black, and near-gray pixels are ignored.
-    /// Returns the average color of the most common color bucket.
-    static func calculate(from thumbnailData: Data) -> RGBColor? {
+    /// Calculates the primary, accent, and contrasting colors from thumbnail image data.
+    /// Primary is the most prominent color overall; accent is the most prominent
+    /// higher-saturation color that isn't the primary; contrasting is the next one after it.
+    static func calculate(from thumbnailData: Data) -> PicColors? {
         guard let image = UIImage(data: thumbnailData),
               let cgImage = image.cgImage else { return nil }
 
@@ -52,18 +52,6 @@ enum ProminentColor {
             // Skip transparent pixels
             guard alpha > 128 else { continue }
 
-            // Skip near-black using perceived luminance
-            let luminance = 0.299 * Double(red) + 0.587 * Double(green) + 0.114 * Double(blue)
-            if luminance < 40 { continue }
-
-            // Skip near-white
-            if luminance > 170 { continue }
-
-            // Skip grays (low chroma)
-            let maxC = max(red, green, blue)
-            let minC = min(red, green, blue)
-            if maxC - minC < 15 { continue }
-
             let bucketR = red >> shift
             let bucketG = green >> shift
             let bucketB = blue >> shift
@@ -75,24 +63,45 @@ enum ProminentColor {
             bucketSumB[bucketIndex] += blue
         }
 
-        // Find the bucket with the most pixels
-        var bestBucket = -1
-        var bestCount = 0
-        for idx in 0..<bucketCount where bucketCounts[idx] > bestCount {
-            bestCount = bucketCounts[idx]
-            bestBucket = idx
+        let averageColor: (Int) -> RGBColor = { bucket in
+            let count = bucketCounts[bucket]
+            return RGBColor(red: bucketSumR[bucket] / count,
+                            green: bucketSumG[bucket] / count,
+                            blue: bucketSumB[bucket] / count)
         }
 
-        guard bestBucket >= 0, bestCount > 0 else {
-            return RGBColor(red: 128, green: 128, blue: 128)
+        // Primary: the most populated bucket overall
+        var primaryBucket = -1
+        var primaryCount = 0
+        for idx in 0..<bucketCount where bucketCounts[idx] > primaryCount {
+            primaryCount = bucketCounts[idx]
+            primaryBucket = idx
         }
 
-        // Average color of the most common bucket
-        let avgR = bucketSumR[bestBucket] / bestCount
-        let avgG = bucketSumG[bestBucket] / bestCount
-        let avgB = bucketSumB[bestBucket] / bestCount
+        guard primaryBucket >= 0 else {
+            let gray = RGBColor(red: 128, green: 128, blue: 128)
+            return PicColors(primary: gray, accent: gray, contrasting: gray)
+        }
 
-        return RGBColor(red: avgR, green: avgG, blue: avgB)
+        let primary = averageColor(primaryBucket)
+
+        // Accent and contrasting: the most populated higher-saturation buckets
+        // that aren't the primary, in descending order of prominence.
+        let saturationThreshold = 0.35
+        var saturatedBuckets: [(bucket: Int, count: Int)] = []
+        for idx in 0..<bucketCount where idx != primaryBucket && bucketCounts[idx] > 0 {
+            if averageColor(idx).saturation >= saturationThreshold {
+                saturatedBuckets.append((bucket: idx, count: bucketCounts[idx]))
+            }
+        }
+        saturatedBuckets.sort { $0.count > $1.count }
+
+        let accent = saturatedBuckets.first.map { averageColor($0.bucket) } ?? primary
+        let contrasting = saturatedBuckets.count > 1
+            ? averageColor(saturatedBuckets[1].bucket)
+            : accent
+
+        return PicColors(primary: primary, accent: accent, contrasting: contrasting)
     }
     // swiftlint:enable function_body_length
 }

--- a/App/Views/Album/AlbumView/AlbumView+Functions.swift
+++ b/App/Views/Album/AlbumView/AlbumView+Functions.swift
@@ -113,16 +113,15 @@ extension AlbumView {
     // swiftlint:disable:next cyclomatic_complexity
     func sortPicsByProminentColor(_ pics: [Pic]) async -> [Pic] {
         let picIDs = pics.map(\.id)
-        let cachedColors = await PColorActor.shared.cachedColors(forPicIDs: picIDs)
+        var colorsMap = await PColorActor.shared.cachedColors(forPicIDs: picIDs)
 
-        var colorsMap = cachedColors
         let uncachedPics = pics.filter { colorsMap[$0.id] == nil && $0.thumbnailData != nil }
 
         if !uncachedPics.isEmpty {
             let maxConcurrent = 8
-            let newColors: [(picID: String, color: RGBColor)] = await withTaskGroup(
-                of: (String, RGBColor?).self,
-                returning: [(picID: String, color: RGBColor)].self
+            let newColors: [(picID: String, colors: PicColors)] = await withTaskGroup(
+                of: (String, PicColors?).self,
+                returning: [(picID: String, colors: PicColors)].self
             ) { group in
                 var iterator = uncachedPics.makeIterator()
 
@@ -130,39 +129,36 @@ extension AlbumView {
                     guard let pic = iterator.next() else { break }
                     group.addTask {
                         guard let thumbnailData = pic.thumbnailData else { return (pic.id, nil) }
-                        let color = ProminentColor.calculate(from: thumbnailData)
-                        return (pic.id, color)
+                        let colors = ProminentColor.calculate(from: thumbnailData)
+                        return (pic.id, colors)
                     }
                 }
 
-                var results: [(picID: String, color: RGBColor)] = []
-                for await (picID, color) in group {
-                    if let color {
-                        results.append((picID: picID, color: color))
+                var results: [(picID: String, colors: PicColors)] = []
+                for await (picID, colors) in group {
+                    if let colors {
+                        results.append((picID: picID, colors: colors))
                     }
                     if let pic = iterator.next() {
                         group.addTask {
                             guard let thumbnailData = pic.thumbnailData else { return (pic.id, nil) }
-                            let color = ProminentColor.calculate(from: thumbnailData)
-                            return (pic.id, color)
+                            let colors = ProminentColor.calculate(from: thumbnailData)
+                            return (pic.id, colors)
                         }
                     }
                 }
                 return results
             }
             for entry in newColors {
-                colorsMap[entry.picID] = entry.color
+                colorsMap[entry.picID] = entry.colors
             }
             await PColorActor.shared.storeColors(newColors)
         }
 
-        let defaultColor = RGBColor(red: 128, green: 128, blue: 128)
+        let gray = RGBColor(red: 128, green: 128, blue: 128)
+        let defaultColors = PicColors(primary: gray, accent: gray, contrasting: gray)
         return pics.sorted { lhs, rhs in
-            let colorA = colorsMap[lhs.id] ?? defaultColor
-            let colorB = colorsMap[rhs.id] ?? defaultColor
-            if colorA.red != colorB.red { return colorA.red < colorB.red }
-            if colorA.green != colorB.green { return colorA.green < colorB.green }
-            return colorA.blue < colorB.blue
+            (colorsMap[lhs.id] ?? defaultColors) < (colorsMap[rhs.id] ?? defaultColors)
         }
     }
 

--- a/PicMate.xcodeproj/project.pbxproj
+++ b/PicMate.xcodeproj/project.pbxproj
@@ -734,7 +734,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.4.2;
+				MARKETING_VERSION = 1.4.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.IllustMate;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -788,7 +788,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.4.2;
+				MARKETING_VERSION = 1.4.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.IllustMate;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -820,7 +820,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.4.2;
+				MARKETING_VERSION = 1.4.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.tsubuzaki.IllustMate.Share-with-IllustMate";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -853,7 +853,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.4.2;
+				MARKETING_VERSION = 1.4.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.tsubuzaki.IllustMate.Share-with-IllustMate";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -885,7 +885,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.4.2;
+				MARKETING_VERSION = 1.4.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.tsubuzaki.IllustMate.Save-to-IllustMate";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -919,7 +919,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.4.2;
+				MARKETING_VERSION = 1.4.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.tsubuzaki.IllustMate.Save-to-IllustMate";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -953,7 +953,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.4.2;
+				MARKETING_VERSION = 1.4.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.IllustMate.Photostand;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -984,7 +984,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.4.2;
+				MARKETING_VERSION = 1.4.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.IllustMate.Photostand;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/Shared/Data Actor/DatabaseMigrator.swift
+++ b/Shared/Data Actor/DatabaseMigrator.swift
@@ -93,12 +93,38 @@ struct DatabaseMigrator {
     // MARK: - PColors DB
 
     static func migrateColorDatabase(_ database: Connection, picColorsTable: Table) {
+        let existingColumns = (try? database.safeRows("PRAGMA table_info(\"pic_colors\")"))?
+            .compactMap { $0[1] as? String } ?? []
+
         let colorRed = Expression<Int>("red")
         let colorGreen = Expression<Int>("green")
         let colorBlue = Expression<Int>("blue")
-        _ = try? database.run(picColorsTable.addColumn(colorRed, defaultValue: 0))
-        _ = try? database.run(picColorsTable.addColumn(colorGreen, defaultValue: 0))
-        _ = try? database.run(picColorsTable.addColumn(colorBlue, defaultValue: 0))
+        if !existingColumns.contains("red") {
+            _ = try? database.run(picColorsTable.addColumn(colorRed, defaultValue: 0))
+        }
+        if !existingColumns.contains("green") {
+            _ = try? database.run(picColorsTable.addColumn(colorGreen, defaultValue: 0))
+        }
+        if !existingColumns.contains("blue") {
+            _ = try? database.run(picColorsTable.addColumn(colorBlue, defaultValue: 0))
+        }
+
+        guard !existingColumns.contains("accent_red") else { return }
+
+        let accentRed = Expression<Int>("accent_red")
+        let accentGreen = Expression<Int>("accent_green")
+        let accentBlue = Expression<Int>("accent_blue")
+        let contrastingRed = Expression<Int>("contrasting_red")
+        let contrastingGreen = Expression<Int>("contrasting_green")
+        let contrastingBlue = Expression<Int>("contrasting_blue")
+        _ = try? database.run(picColorsTable.addColumn(accentRed, defaultValue: 0))
+        _ = try? database.run(picColorsTable.addColumn(accentGreen, defaultValue: 0))
+        _ = try? database.run(picColorsTable.addColumn(accentBlue, defaultValue: 0))
+        _ = try? database.run(picColorsTable.addColumn(contrastingRed, defaultValue: 0))
+        _ = try? database.run(picColorsTable.addColumn(contrastingGreen, defaultValue: 0))
+        _ = try? database.run(picColorsTable.addColumn(contrastingBlue, defaultValue: 0))
+
+        _ = try? database.run(picColorsTable.delete())
     }
 
     // MARK: - Cover Cache DB

--- a/Shared/Data Actor/PColorActor.swift
+++ b/Shared/Data Actor/PColorActor.swift
@@ -27,6 +27,12 @@ actor PColorActor {
     let colorRed = Expression<Int>("red")
     let colorGreen = Expression<Int>("green")
     let colorBlue = Expression<Int>("blue")
+    let colorAccentRed = Expression<Int>("accent_red")
+    let colorAccentGreen = Expression<Int>("accent_green")
+    let colorAccentBlue = Expression<Int>("accent_blue")
+    let colorContrastingRed = Expression<Int>("contrasting_red")
+    let colorContrastingGreen = Expression<Int>("contrasting_green")
+    let colorContrastingBlue = Expression<Int>("contrasting_blue")
 
     init(collectionID: String) {
         self.collectionID = collectionID
@@ -61,6 +67,12 @@ actor PColorActor {
                 table.column(colorRed)
                 table.column(colorGreen)
                 table.column(colorBlue)
+                table.column(colorAccentRed, defaultValue: 0)
+                table.column(colorAccentGreen, defaultValue: 0)
+                table.column(colorAccentBlue, defaultValue: 0)
+                table.column(colorContrastingRed, defaultValue: 0)
+                table.column(colorContrastingGreen, defaultValue: 0)
+                table.column(colorContrastingBlue, defaultValue: 0)
             })
             if DatabaseMigrator.migrationNeeded() {
                 DatabaseMigrator.migrateColorDatabase(database, picColorsTable: picColorsTable)
@@ -72,44 +84,64 @@ actor PColorActor {
 
     // MARK: - Read
 
-    func cachedColor(forPicWithID picID: String) -> RGBColor? {
+    func cachedColor(forPicWithID picID: String) -> PicColors? {
         let query = picColorsTable.filter(colorPicId == picID)
-            .select(colorRed, colorGreen, colorBlue)
         guard let row = try? database.pluck(query),
-              let red = try? row.get(colorRed),
-              let green = try? row.get(colorGreen),
-              let blue = try? row.get(colorBlue) else { return nil }
-        return RGBColor(red: red, green: green, blue: blue)
+              let primary = try? RGBColor(red: row.get(colorRed),
+                                          green: row.get(colorGreen),
+                                          blue: row.get(colorBlue)),
+              let accent = try? RGBColor(red: row.get(colorAccentRed),
+                                         green: row.get(colorAccentGreen),
+                                         blue: row.get(colorAccentBlue)),
+              let contrasting = try? RGBColor(red: row.get(colorContrastingRed),
+                                              green: row.get(colorContrastingGreen),
+                                              blue: row.get(colorContrastingBlue)) else { return nil }
+        return PicColors(primary: primary, accent: accent, contrasting: contrasting)
     }
 
-    func allCachedColors() -> [String: RGBColor] {
-        let query = picColorsTable.select(colorPicId, colorRed, colorGreen, colorBlue)
+    func allCachedColors() -> [String: PicColors] {
+        let query = picColorsTable.select(
+            colorPicId, colorRed, colorGreen, colorBlue,
+            colorAccentRed, colorAccentGreen, colorAccentBlue,
+            colorContrastingRed, colorContrastingGreen, colorContrastingBlue
+        )
         guard let rows = try? database.safeRows(query) else { return [:] }
-        var result: [String: RGBColor] = [:]
+        var result: [String: PicColors] = [:]
         for row in rows {
             guard let picID = try? row.get(colorPicId),
-                  let red = try? row.get(colorRed),
-                  let green = try? row.get(colorGreen),
-                  let blue = try? row.get(colorBlue) else { continue }
-            result[picID] = RGBColor(red: red, green: green, blue: blue)
+                  let primary = try? RGBColor(red: row.get(colorRed),
+                                              green: row.get(colorGreen),
+                                              blue: row.get(colorBlue)),
+                  let accent = try? RGBColor(red: row.get(colorAccentRed),
+                                             green: row.get(colorAccentGreen),
+                                             blue: row.get(colorAccentBlue)),
+                  let contrasting = try? RGBColor(red: row.get(colorContrastingRed),
+                                                  green: row.get(colorContrastingGreen),
+                                                  blue: row.get(colorContrastingBlue)) else { continue }
+            result[picID] = PicColors(primary: primary, accent: accent, contrasting: contrasting)
         }
         return result
     }
 
-    func cachedColors(forPicIDs picIDs: [String]) -> [String: RGBColor] {
+    func cachedColors(forPicIDs picIDs: [String]) -> [String: PicColors] {
         guard !picIDs.isEmpty else { return [:] }
         let placeholders = picIDs.map { _ in "?" }.joined(separator: ", ")
-        let sql = "SELECT pic_id, red, green, blue FROM pic_colors WHERE pic_id IN (\(placeholders))"
+        let sql = """
+        SELECT pic_id, red, green, blue, accent_red, accent_green, accent_blue, \
+        contrasting_red, contrasting_green, contrasting_blue \
+        FROM pic_colors WHERE pic_id IN (\(placeholders))
+        """
         let bindings: [Binding?] = picIDs.map { $0 as Binding? }
         guard let stmt = try? database.safeRows(sql, bindings) else { return [:] }
-        var result: [String: RGBColor] = [:]
+        var result: [String: PicColors] = [:]
         for row in stmt {
-            if let picID = row[0] as? String,
-               let red = row[1] as? Int64,
-               let green = row[2] as? Int64,
-               let blue = row[3] as? Int64 {
-                result[picID] = RGBColor(red: Int(red), green: Int(green), blue: Int(blue))
-            }
+            guard let picID = row[0] as? String else { continue }
+            let values = (1...9).map { (row[$0] as? Int64).map(Int.init) ?? 0 }
+            result[picID] = PicColors(
+                primary: RGBColor(red: values[0], green: values[1], blue: values[2]),
+                accent: RGBColor(red: values[3], green: values[4], blue: values[5]),
+                contrasting: RGBColor(red: values[6], green: values[7], blue: values[8])
+            )
         }
         return result
     }
@@ -128,27 +160,34 @@ actor PColorActor {
 
     // MARK: - Write
 
-    func storeColor(red: Int, green: Int, blue: Int, forPicWithID picID: String) {
-        _ = try? database.run(picColorsTable.insert(or: .replace,
-            colorPicId <- picID,
-            colorRed <- red,
-            colorGreen <- green,
-            colorBlue <- blue
-        ))
+    func storeColor(_ colors: PicColors, forPicWithID picID: String) {
+        _ = try? database.run(picColorsTable.insert(or: .replace, setters(for: picID, colors: colors)))
     }
 
-    func storeColors(_ colors: [(picID: String, color: RGBColor)]) {
+    func storeColors(_ colors: [(picID: String, colors: PicColors)]) {
         guard !colors.isEmpty else { return }
         _ = try? database.transaction {
             for entry in colors {
-                _ = try? database.run(picColorsTable.insert(or: .replace,
-                    colorPicId <- entry.picID,
-                    colorRed <- entry.color.red,
-                    colorGreen <- entry.color.green,
-                    colorBlue <- entry.color.blue
-                ))
+                _ = try? database.run(
+                    picColorsTable.insert(or: .replace, setters(for: entry.picID, colors: entry.colors))
+                )
             }
         }
+    }
+
+    private func setters(for picID: String, colors: PicColors) -> [Setter] {
+        [
+            colorPicId <- picID,
+            colorRed <- colors.primary.red,
+            colorGreen <- colors.primary.green,
+            colorBlue <- colors.primary.blue,
+            colorAccentRed <- colors.accent.red,
+            colorAccentGreen <- colors.accent.green,
+            colorAccentBlue <- colors.accent.blue,
+            colorContrastingRed <- colors.contrasting.red,
+            colorContrastingGreen <- colors.contrasting.green,
+            colorContrastingBlue <- colors.contrasting.blue
+        ]
     }
 
     // MARK: - Delete

--- a/Shared/Data Models/RGBColor.swift
+++ b/Shared/Data Models/RGBColor.swift
@@ -17,20 +17,20 @@ extension RGBColor {
     }
 
     var hue: Double {
-        let r = Double(red) / 255.0
-        let g = Double(green) / 255.0
-        let b = Double(blue) / 255.0
-        let maxC = max(r, g, b)
-        let minC = min(r, g, b)
+        let red = Double(red) / 255.0
+        let green = Double(green) / 255.0
+        let blue = Double(blue) / 255.0
+        let maxC = max(red, green, blue)
+        let minC = min(red, green, blue)
         let delta = maxC - minC
         guard delta > 0 else { return 0 }
         var hue: Double
-        if maxC == r {
-            hue = (g - b) / delta
-        } else if maxC == g {
-            hue = 2 + (b - r) / delta
+        if maxC == red {
+            hue = (green - blue) / delta
+        } else if maxC == green {
+            hue = 2 + (blue - red) / delta
         } else {
-            hue = 4 + (r - g) / delta
+            hue = 4 + (red - green) / delta
         }
         hue *= 60
         if hue < 0 { hue += 360 }

--- a/Shared/Data Models/RGBColor.swift
+++ b/Shared/Data Models/RGBColor.swift
@@ -3,3 +3,62 @@ struct RGBColor: Equatable {
     let green: Int
     let blue: Int
 }
+
+extension RGBColor {
+    var saturation: Double {
+        let maxC = Double(max(red, green, blue))
+        let minC = Double(min(red, green, blue))
+        guard maxC > 0 else { return 0 }
+        return (maxC - minC) / maxC
+    }
+
+    var brightness: Double {
+        Double(max(red, green, blue)) / 255.0
+    }
+
+    var hue: Double {
+        let r = Double(red) / 255.0
+        let g = Double(green) / 255.0
+        let b = Double(blue) / 255.0
+        let maxC = max(r, g, b)
+        let minC = min(r, g, b)
+        let delta = maxC - minC
+        guard delta > 0 else { return 0 }
+        var hue: Double
+        if maxC == r {
+            hue = (g - b) / delta
+        } else if maxC == g {
+            hue = 2 + (b - r) / delta
+        } else {
+            hue = 4 + (r - g) / delta
+        }
+        hue *= 60
+        if hue < 0 { hue += 360 }
+        return hue
+    }
+
+    var sortKey: (Int, Double, Double) {
+        if saturation < 0.12 {
+            return (1, brightness, 0)
+        }
+        return (0, hue, brightness)
+    }
+}
+
+struct PicColors: Equatable {
+    let primary: RGBColor
+    let accent: RGBColor
+    let contrasting: RGBColor
+}
+
+extension PicColors: Comparable {
+    static func < (lhs: PicColors, rhs: PicColors) -> Bool {
+        if lhs.primary.sortKey != rhs.primary.sortKey {
+            return lhs.primary.sortKey < rhs.primary.sortKey
+        }
+        if lhs.accent.sortKey != rhs.accent.sortKey {
+            return lhs.accent.sortKey < rhs.accent.sortKey
+        }
+        return lhs.contrasting.sortKey < rhs.contrasting.sortKey
+    }
+}


### PR DESCRIPTION
## Summary

Updates color sorting to operate on three colors derived from each pic's thumbnail instead of a single prominent color:

- **Primary** — the most prominent color overall (the dominant color in the thumbnail).
- **Accent** — the most prominent *higher-saturation* color that isn't the primary.
- **Contrasting** — the next higher-saturation color after the accent.

Pics are then ordered by primary → accent → contrasting. Chromatic colors are grouped by hue, with achromatic (near-gray/white/black) colors grouped together by brightness, giving a cleaner visual gradient than the previous raw-RGB ordering.

## Changes

- **`ProminentColor`** now returns a `PicColors` triple. It quantizes the 32×32 thumbnail into color buckets, picks the most populated bucket as the primary, then ranks the remaining higher-saturation buckets by prominence to choose the accent and contrasting colors.
- **`RGBColor`** gains `hue`/`saturation`/`brightness` helpers and a `sortKey`; new `PicColors` struct conforms to `Comparable` to encapsulate the sort ordering.
- **`PColorActor`** stores accent and contrasting colors alongside the primary (six new columns) and reads them back as `PicColors`.
- **`DatabaseMigrator.migrateColorDatabase`** adds the new columns and clears stale single-color cache entries once, so they recompute with the full triple. Fresh installs get the columns via the table create.
- **`AlbumView.sortPicsByProminentColor`** computes/caches `PicColors` and sorts using the new comparator.

## Notes

- The color cache is recomputed lazily on the next "prominent color" sort, so existing users see no data loss — only a one-time recompute.
- Schema changes follow the repo's existing version-gated migration pattern; the new columns are added when the app version bumps on release (fresh installs are covered by the table create).

https://claude.ai/code/session_012dGfEwvTCmwY52b1H16NKz

---
_Generated by [Claude Code](https://claude.ai/code/session_012dGfEwvTCmwY52b1H16NKz)_