### PR TITLE
Show last used album in Move To context menu

### DIFF
--- a/App/Classes/LastUsedAlbum.swift
+++ b/App/Classes/LastUsedAlbum.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+enum LastUsedAlbum {
+
+    private static let key = "LastUsedMoveDestinationAlbumID"
+
+    private static var defaults: UserDefaults? {
+        UserDefaults(suiteName: "group.com.tsubuzaki.IllustMate")
+    }
+
+    static var id: String? {
+        guard let value = defaults?.string(forKey: key), !value.isEmpty else { return nil }
+        return value
+    }
+
+    static func set(_ albumID: String) {
+        defaults?.set(albumID, forKey: key)
+    }
+
+    static func clear() {
+        defaults?.removeObject(forKey: key)
+    }
+}

--- a/App/Classes/LastUsedAlbum.swift
+++ b/App/Classes/LastUsedAlbum.swift
@@ -2,22 +2,30 @@ import Foundation
 
 enum LastUsedAlbum {
 
-    private static let key = "LastUsedMoveDestinationAlbumID"
+    private static let key = "LastUsedMoveDestinationAlbumIDs"
 
     private static var defaults: UserDefaults? {
         UserDefaults(suiteName: "group.com.tsubuzaki.IllustMate")
     }
 
-    static var id: String? {
-        guard let value = defaults?.string(forKey: key), !value.isEmpty else { return nil }
+    private static func all() -> [String: String] {
+        defaults?.dictionary(forKey: key) as? [String: String] ?? [:]
+    }
+
+    static func id(in collectionID: String) -> String? {
+        guard let value = all()[collectionID], !value.isEmpty else { return nil }
         return value
     }
 
-    static func set(_ albumID: String) {
-        defaults?.set(albumID, forKey: key)
+    static func set(_ albumID: String, in collectionID: String) {
+        var map = all()
+        map[collectionID] = albumID
+        defaults?.set(map, forKey: key)
     }
 
-    static func clear() {
-        defaults?.removeObject(forKey: key)
+    static func clear(in collectionID: String) {
+        var map = all()
+        map[collectionID] = nil
+        defaults?.set(map, forKey: key)
     }
 }

--- a/App/Views/Album/AlbumMoveMenu.swift
+++ b/App/Views/Album/AlbumMoveMenu.swift
@@ -8,6 +8,7 @@ struct AlbumMoveMenu: View {
     var onOtherLibraries: () -> Void
 
     @State var rootAlbums: [Album] = []
+    @State var lastUsedAlbum: Album?
 
     var body: some View {
         if album.parentAlbumID != nil {
@@ -19,21 +20,27 @@ struct AlbumMoveMenu: View {
             }
         }
         Menu("Shared.MoveTo", systemImage: "tray.and.arrow.down") {
-            ForEach(rootAlbums) { rootAlbum in
-                AlbumHierarchyMenuItem(
-                    targetAlbum: rootAlbum,
-                    excludingAlbumID: album.id
-                ) { destinationAlbum in
-                    Task {
-                        await DataActor.shared.addAlbum(withID: album.id,
-                                             toAlbumWithID: destinationAlbum.id)
-                        onMoved()
+            if let lastUsedAlbum, lastUsedAlbum.id != album.id {
+                Section {
+                    Button(lastUsedAlbum.name, systemImage: "clock.arrow.circlepath") {
+                        move(to: lastUsedAlbum)
                     }
                 }
             }
-            Divider()
-            Button("Shared.MoveToOtherLibrary", systemImage: "square.stack.3d.up") {
-                onOtherLibraries()
+            Section {
+                ForEach(rootAlbums) { rootAlbum in
+                    AlbumHierarchyMenuItem(
+                        targetAlbum: rootAlbum,
+                        excludingAlbumID: album.id
+                    ) { destinationAlbum in
+                        move(to: destinationAlbum)
+                    }
+                }
+            }
+            Section {
+                Button("Shared.MoveToOtherLibrary", systemImage: "square.stack.3d.up") {
+                    onOtherLibraries()
+                }
             }
         }
         .task {
@@ -41,8 +48,22 @@ struct AlbumMoveMenu: View {
         }
     }
 
+    func move(to destinationAlbum: Album) {
+        Task {
+            await DataActor.shared.addAlbum(withID: album.id,
+                                            toAlbumWithID: destinationAlbum.id)
+            LastUsedAlbum.set(destinationAlbum.id)
+            onMoved()
+        }
+    }
+
     func loadAlbums() async {
         rootAlbums = (try? await DataActor.shared.albumsWithCounts(in: nil, sortedBy: .nameAscending)) ?? []
+        if let id = LastUsedAlbum.id {
+            lastUsedAlbum = await DataActor.shared.album(for: id)
+        } else {
+            lastUsedAlbum = nil
+        }
     }
 }
 

--- a/App/Views/Album/AlbumMoveMenu.swift
+++ b/App/Views/Album/AlbumMoveMenu.swift
@@ -52,14 +52,14 @@ struct AlbumMoveMenu: View {
         Task {
             await DataActor.shared.addAlbum(withID: album.id,
                                             toAlbumWithID: destinationAlbum.id)
-            LastUsedAlbum.set(destinationAlbum.id)
+            LastUsedAlbum.set(destinationAlbum.id, in: DataActor.shared.collectionID)
             onMoved()
         }
     }
 
     func loadAlbums() async {
         rootAlbums = (try? await DataActor.shared.albumsWithCounts(in: nil, sortedBy: .nameAscending)) ?? []
-        if let id = LastUsedAlbum.id {
+        if let id = LastUsedAlbum.id(in: DataActor.shared.collectionID) {
             lastUsedAlbum = await DataActor.shared.album(for: id)
         } else {
             lastUsedAlbum = nil

--- a/App/Views/Album/PicMoveMenu.swift
+++ b/App/Views/Album/PicMoveMenu.swift
@@ -66,14 +66,14 @@ struct PicMoveMenu: View {
                 AlbumCoverCache.shared.removeImages(forAlbumID: containingAlbum.id)
             }
             AlbumCoverCache.shared.removeImages(forAlbumID: destinationAlbum.id)
-            LastUsedAlbum.set(destinationAlbum.id)
+            LastUsedAlbum.set(destinationAlbum.id, in: DataActor.shared.collectionID)
             onMoved()
         }
     }
 
     func loadAlbums() async {
         rootAlbums = (try? await DataActor.shared.albumsWithCounts(in: nil, sortedBy: .nameAscending)) ?? []
-        if let id = LastUsedAlbum.id {
+        if let id = LastUsedAlbum.id(in: DataActor.shared.collectionID) {
             lastUsedAlbum = await DataActor.shared.album(for: id)
         } else {
             lastUsedAlbum = nil

--- a/App/Views/Album/PicMoveMenu.swift
+++ b/App/Views/Album/PicMoveMenu.swift
@@ -11,6 +11,7 @@ struct PicMoveMenu: View {
     var onOtherLibraries: () -> Void
 
     @State var rootAlbums: [Album] = []
+    @State var lastUsedAlbum: Album?
 
     var body: some View {
         Menu(title, systemImage: systemImage) {
@@ -27,6 +28,13 @@ struct PicMoveMenu: View {
                     }
                 }
             }
+            if let lastUsedAlbum, lastUsedAlbum.id != containingAlbum?.id {
+                Section {
+                    Button(lastUsedAlbum.name, systemImage: "clock.arrow.circlepath") {
+                        move(to: lastUsedAlbum)
+                    }
+                }
+            }
             if !rootAlbums.isEmpty {
                 Section {
                     ForEach(rootAlbums) { album in
@@ -34,15 +42,7 @@ struct PicMoveMenu: View {
                             targetAlbum: album,
                             excludingAlbumID: containingAlbum?.id ?? ""
                         ) { destinationAlbum in
-                            Task {
-                                await DataActor.shared.addPics(withIDs: pics.map { $0.id },
-                                                               toAlbumWithID: destinationAlbum.id)
-                                if let containingAlbum {
-                                    AlbumCoverCache.shared.removeImages(forAlbumID: containingAlbum.id)
-                                }
-                                AlbumCoverCache.shared.removeImages(forAlbumID: destinationAlbum.id)
-                                onMoved()
-                            }
+                            move(to: destinationAlbum)
                         }
                     }
                 }
@@ -58,7 +58,25 @@ struct PicMoveMenu: View {
         }
     }
 
+    func move(to destinationAlbum: Album) {
+        Task {
+            await DataActor.shared.addPics(withIDs: pics.map { $0.id },
+                                           toAlbumWithID: destinationAlbum.id)
+            if let containingAlbum {
+                AlbumCoverCache.shared.removeImages(forAlbumID: containingAlbum.id)
+            }
+            AlbumCoverCache.shared.removeImages(forAlbumID: destinationAlbum.id)
+            LastUsedAlbum.set(destinationAlbum.id)
+            onMoved()
+        }
+    }
+
     func loadAlbums() async {
         rootAlbums = (try? await DataActor.shared.albumsWithCounts(in: nil, sortedBy: .nameAscending)) ?? []
+        if let id = LastUsedAlbum.id {
+            lastUsedAlbum = await DataActor.shared.album(for: id)
+        } else {
+            lastUsedAlbum = nil
+        }
     }
 }


### PR DESCRIPTION
Closes #13

Adds the last used move destination album to the top of the **Move To** context menu, arranged as:

- `<last used>` (only when it still exists in the current library and isn't the source/containing album)
- separator
- `<albums>`
- separator
- Other Libraries…

## Changes

- **`LastUsedAlbum`** — a small `UserDefaults`-backed store (app group) holding the ID of the most recent move destination, mirroring the existing `OfflineAlbums` pattern.
- **`PicMoveMenu`** / **`AlbumMoveMenu`** — record the destination via `LastUsedAlbum.set(_:)` whenever a move into an album happens, and surface the last used album as a quick-access entry at the top of the menu. The entry is resolved through `DataActor.album(for:)` so a deleted (or other-library) album simply doesn't appear.

The new section uses SwiftUI `Section` blocks so the separators fall out naturally, matching the existing menu structure.

https://claude.ai/code/session_01GUxsbn1tCbPCERDwvH5Kir

---
_Generated by [Claude Code](https://claude.ai/code/session_01GUxsbn1tCbPCERDwvH5Kir)_