### PR TITLE
Show a toast when copying pics

### DIFF
--- a/App/Classes/CopiedToast.swift
+++ b/App/Classes/CopiedToast.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@MainActor
+enum CopiedToast {
+    static func showCopied() {
+        ToastManager.shared.show(ToastItem(
+            message: String(localized: "Toast.Copied", table: "Photos"),
+            systemImage: "doc.on.doc.fill"))
+    }
+}

--- a/App/Views/Album/PicsGrid.swift
+++ b/App/Views/Album/PicsGrid.swift
@@ -156,6 +156,7 @@ struct PicsGrid<Content: View>: View {
                                let image = UIImage(data: data) {
                                 UIPasteboard.general.image = image
                                 UINotificationFeedbackGenerator().notificationOccurred(.success)
+                                CopiedToast.showCopied()
                             }
                         }
                     }

--- a/App/Views/Photos/PhotosAssetsGrid.swift
+++ b/App/Views/Photos/PhotosAssetsGrid.swift
@@ -199,6 +199,9 @@ struct PhotosAssetContextMenu: View {
                         DispatchQueue.main.async {
                             UIPasteboard.general.image = result
                             UINotificationFeedbackGenerator().notificationOccurred(.success)
+                            MainActor.assumeIsolated {
+                                CopiedToast.showCopied()
+                            }
                         }
                     }
                 }

--- a/App/Views/Viewer/PhotosAssetViewer/PhotosAssetViewer.swift
+++ b/App/Views/Viewer/PhotosAssetViewer/PhotosAssetViewer.swift
@@ -105,6 +105,7 @@ struct PhotosAssetViewer: View {
                             if let image = currentImage {
                                 UIPasteboard.general.image = image
                                 UINotificationFeedbackGenerator().notificationOccurred(.success)
+                                CopiedToast.showCopied()
                             }
                         }
                         .disabled(currentImage == nil)
@@ -146,6 +147,7 @@ struct PhotosAssetViewer: View {
                             if let image = currentImage {
                                 UIPasteboard.general.image = image
                                 UINotificationFeedbackGenerator().notificationOccurred(.success)
+                                CopiedToast.showCopied()
                             }
                         }
                         .disabled(currentImage == nil)

--- a/App/Views/Viewer/PicViewer/PicViewer.swift
+++ b/App/Views/Viewer/PicViewer/PicViewer.swift
@@ -162,6 +162,7 @@ struct PicViewer: View {
                             if let image = currentImage {
                                 UIPasteboard.general.image = image
                                 UINotificationFeedbackGenerator().notificationOccurred(.success)
+                                CopiedToast.showCopied()
                             }
                         }
                         .disabled(currentImage == nil)
@@ -203,6 +204,7 @@ struct PicViewer: View {
                             if let image = currentImage {
                                 UIPasteboard.general.image = image
                                 UINotificationFeedbackGenerator().notificationOccurred(.success)
+                                CopiedToast.showCopied()
                             }
                         }
                         .disabled(currentImage == nil)

--- a/PicMate.xcodeproj/project.pbxproj
+++ b/PicMate.xcodeproj/project.pbxproj
@@ -734,7 +734,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.5.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.IllustMate;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -788,7 +788,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.5.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.IllustMate;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -820,7 +820,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.5.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.tsubuzaki.IllustMate.Share-with-IllustMate";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -853,7 +853,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.5.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.tsubuzaki.IllustMate.Share-with-IllustMate";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -885,7 +885,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.5.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.tsubuzaki.IllustMate.Save-to-IllustMate";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -919,7 +919,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.5.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.tsubuzaki.IllustMate.Save-to-IllustMate";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -953,7 +953,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.5.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.IllustMate.Photostand;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -984,7 +984,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.5.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.IllustMate.Photostand;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/Shared/Strings/Photos.xcstrings
+++ b/Shared/Strings/Photos.xcstrings
@@ -2092,6 +2092,47 @@
         }
       }
     },
+    "Toast.Copied" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In Zwischenablage kopiert"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copied to clipboard"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クリップボードにコピーしました"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "클립보드에 복사함"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已复制到剪贴板"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已複製到剪貼簿"
+          }
+        }
+      }
+    },
     "Toast.MovedAlbumToLibrary.%@-%@" : {
       "extractionState" : "manual",
       "localizations" : {


### PR DESCRIPTION
## Summary

Using the same logic as the move toast, this adds a "copied" toast that appears whenever a pic is copied to the clipboard.

- New `CopiedToast` helper mirroring `MovedToast`, routing through the shared `ToastManager`/`ToastItem` system (no undo action, since a clipboard copy can't be undone).
- Surfaced from every copy entry point:
  - Pic grid context menu (`PicsGrid`)
  - Photos asset grid context menu (`PhotosAssetsGrid`)
  - Pic viewer toolbar (`PicViewer`, both layout variants)
  - Photos asset viewer toolbar (`PhotosAssetViewer`, both layout variants)
- Added the `Toast.Copied` string ("Copied to clipboard") to `Photos.xcstrings`, localized for all six supported languages.

The toast overlay is attached at the app root and renders over pushed viewer destinations, so it shows in both menus and the viewer.

### Notes
- In `PhotosAssetsGrid` the copy happens inside a `DispatchQueue.main.async` completion handler, so the `@MainActor` call is wrapped in `MainActor.assumeIsolated` to stay clean under Swift 6 strict concurrency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6DuW71TvanzCMMWAETH5L

---
_Generated by [Claude Code](https://claude.ai/code/session_01X6DuW71TvanzCMMWAETH5L)_